### PR TITLE
Fix links for "examples" and "building your first layout"

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ We provide multiple kits containing **themable pre-styled components**. Inspired
 > Some familiarity with
 > react, threejs, and @react-three/fiber, is recommended.
 
-Get started with **[building your first layout](https://docs.pmnd.rs/uikit/getting-started/first-layout.md)**, take a look at our **[examples](https://docs.pmnd.rs/uikit/getting-started/examples.md)** to see uikit in action, or learn more about:
+Get started with **[building your first layout](https://docs.pmnd.rs/uikit/getting-started/first-layout)**, take a look at our **[examples](https://docs.pmnd.rs/uikit/getting-started/examples)** to see uikit in action, or learn more about:
 
 - [All components and their properties](https://docs.pmnd.rs/uikit/getting-started/components-and-properties)
 - [Interacitivity](https://docs.pmnd.rs/uikit/tutorials/interactivity)


### PR DESCRIPTION
The current links lead to a 404 page

<img width="511" alt="CleanShot 2024-03-10 at 13 37 25@2x" src="https://github.com/pmndrs/uikit/assets/22670878/fbb90df4-d3f1-4bb7-95ec-58fff1cfd217">
