### PR TITLE
fix: prevent portal from distorting on viewport resize.

### DIFF
--- a/examples/uikit/src/App.tsx
+++ b/examples/uikit/src/App.tsx
@@ -1,6 +1,6 @@
 import { ComponentRef, StrictMode, Suspense, useMemo, useRef, useState } from 'react'
 import { Canvas } from '@react-three/fiber'
-import { Gltf, Box, PerspectiveCamera, RenderTexture, OrbitControls } from '@react-three/drei'
+import { Box, PerspectiveCamera, OrthographicCamera, RenderTexture, OrbitControls } from '@react-three/drei'
 import { signal } from '@preact/signals-core'
 import {
   DefaultProperties,
@@ -51,11 +51,31 @@ export default function App() {
             borderRightWidth={0}
             borderColor="red"
           >
-            <Portal flexShrink={0} borderRadius={30} width="100%" height={500}>
-              <Box rotation-y={Math.PI / 4} args={[2, 2, 2]} />
-              <color attach="background" args={['red']} />
-            </Portal>
-            <Container flexShrink={0} flexDirection="column" backgroundColor="blue" width={100} positionType="relative">
+            {/* Tests for the Portal component.*/}
+            <Container flexShrink={0} flexDirection="row" height={500}>
+              {/* By default, the Portal should create it's own camera and thus
+                not be affected by the scene camera and orbit controls..*/}
+              <Portal borderRadius={30} width="33%">
+                <Box rotation-y={Math.PI / 4} args={[2, 2, 2]} />
+                <color attach="background" args={['red']} />
+              </Portal>
+              {/* However, we can provide a camera with custom properties, like
+                a different position or field of view. Note that the aspect
+                ratio will be overriden to match with the screens aspect ratio,
+                s.t. resizing the screen would not distort the portal view.*/}
+              <Portal borderRadius={30} width="33%">
+                <PerspectiveCamera makeDefault position={[0, -1, 4]} fov={500} aspect={100}/>
+                <Box rotation-y={Math.PI / 4} args={[2, 2, 2]} />
+                <color attach="background" args={['blue']} />
+              </Portal>
+              {/* The resizing should work for the orthographic camera as well.*/}
+              <Portal borderRadius={30} width="33%">
+                <OrthographicCamera makeDefault position={[0, 2, 100]} left={10} right={10} top={10} bottom={10}/>
+                <Box rotation-y={Math.PI / 4} args={[2, 2, 2]} />
+                <color attach="background" args={['green']} />
+              </Portal>
+            </Container>
+           <Container flexShrink={0} flexDirection="column" backgroundColor="blue" width={100} positionType="relative">
               <Container flexDirection="column">
                 <Text wordBreak="break-all" height={100}>
                   Escribe algo...

--- a/examples/uikit/src/App.tsx
+++ b/examples/uikit/src/App.tsx
@@ -64,18 +64,26 @@ export default function App() {
                 ratio will be overriden to match with the screens aspect ratio,
                 s.t. resizing the screen would not distort the portal view.*/}
               <Portal borderRadius={30} width="33%">
-                <PerspectiveCamera makeDefault position={[0, -1, 4]} fov={500} aspect={100}/>
+                <PerspectiveCamera makeDefault position={[0, -1, 4]} fov={500} aspect={100} />
                 <Box rotation-y={Math.PI / 4} args={[2, 2, 2]} />
                 <color attach="background" args={['blue']} />
               </Portal>
               {/* The resizing should work for the orthographic camera as well.*/}
               <Portal borderRadius={30} width="33%">
-                <OrthographicCamera makeDefault position={[0, 2, 100]} left={10} right={10} top={10} bottom={10}/>
+                <OrthographicCamera
+                  makeDefault
+                  position={[0, 0, 100]}
+                  left={10}
+                  right={10}
+                  top={10}
+                  zoom={100}
+                  bottom={10}
+                />
                 <Box rotation-y={Math.PI / 4} args={[2, 2, 2]} />
                 <color attach="background" args={['green']} />
               </Portal>
             </Container>
-           <Container flexShrink={0} flexDirection="column" backgroundColor="blue" width={100} positionType="relative">
+            <Container flexShrink={0} flexDirection="column" backgroundColor="blue" width={100} positionType="relative">
               <Container flexDirection="column">
                 <Text wordBreak="break-all" height={100}>
                   Escribe algo...

--- a/examples/uikit/src/App.tsx
+++ b/examples/uikit/src/App.tsx
@@ -1,6 +1,6 @@
 import { ComponentRef, StrictMode, Suspense, useMemo, useRef, useState } from 'react'
 import { Canvas } from '@react-three/fiber'
-import { Gltf, Box, PerspectiveCamera, RenderTexture } from '@react-three/drei'
+import { Gltf, Box, PerspectiveCamera, RenderTexture, OrbitControls } from '@react-three/drei'
 import { signal } from '@preact/signals-core'
 import {
   DefaultProperties,
@@ -31,18 +31,14 @@ export default function App() {
   return (
     <Canvas frameloop="demand" style={{ height: '100dvh', touchAction: 'none' }} gl={{ localClippingEnabled: true }}>
       <StrictMode>
+        <OrbitControls />
         <FontFamilyProvider inter={{ normal: 'inter-normal.json' }}>
           <color attach="background" args={['black']} />
           <ambientLight intensity={0.5} />
           <directionalLight intensity={10} position={[5, 1, 10]} />
-          <Gltf position={[200, 0, 200]} scale={0.1} src="scene.glb" />
-          <Gltf position={[0, 0, 4]} scale={10} src="example.glb" />
           <RenderTexture ref={(t) => (texture.value = t ?? undefined)}>
             <Box />
           </RenderTexture>
-          <Box renderOrder={1} position={[0, 0, 4]} scale={0.2}>
-            <meshBasicMaterial depthWrite={false} transparent color="red" />
-          </Box>
           <Fullscreen
             renderOrder={10}
             distanceToCamera={1}
@@ -55,8 +51,7 @@ export default function App() {
             borderRightWidth={0}
             borderColor="red"
           >
-            <Portal flexShrink={0} borderRadius={30} width={200} aspectRatio={1}>
-              <PerspectiveCamera makeDefault position={[0, 0, 4]} />
+            <Portal flexShrink={0} borderRadius={30} width="100%" height={500}>
               <Box rotation-y={Math.PI / 4} args={[2, 2, 2]} />
               <color attach="background" args={['red']} />
             </Portal>

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,7 +46,8 @@
     "ora": "^8.0.1",
     "prettier": "^3.2.5",
     "prompts": "^2.4.2",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@react-three/drei": "^9.96.1",

--- a/packages/react/src/portal.tsx
+++ b/packages/react/src/portal.tsx
@@ -118,7 +118,6 @@ export const Portal: (props: PortalProperties & RefAttributes<ComponentInternals
                 newOwnState = newOwnState(get())
               }
               Object.assign(ownState, newOwnState)
-              console.log(newOwnState.camera)
               update()
             },
             setPreviousState(prevState: RootState) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -568,6 +568,9 @@ importers:
       zod:
         specifier: ^3.22.4
         version: 3.22.4
+      zustand:
+        specifier: ^4.5.2
+        version: 4.5.2(@types/react@18.3.1)(react@18.2.0)
     devDependencies:
       '@react-three/drei':
         specifier: ^9.96.1
@@ -10623,7 +10626,7 @@ packages:
   /tunnel-rat@0.1.2(@types/react@18.3.1)(react@18.2.0):
     resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
     dependencies:
-      zustand: 4.4.7(@types/react@18.3.1)(react@18.2.0)
+      zustand: 4.5.2(@types/react@18.3.1)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -10633,7 +10636,7 @@ packages:
   /tunnel-rat@0.1.2(@types/react@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
     dependencies:
-      zustand: 4.4.7(@types/react@18.3.1)(react@18.3.1)
+      zustand: 4.5.2(@types/react@18.3.1)(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -10902,7 +10905,6 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.2.0
-    dev: true
 
   /use-sync-external-store@1.2.0(react@18.3.1):
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
@@ -11370,26 +11372,6 @@ packages:
       use-sync-external-store: 1.2.0(react@18.3.1)
     dev: false
 
-  /zustand@4.4.7(@types/react@18.3.1)(react@18.2.0):
-    resolution: {integrity: sha512-QFJWJMdlETcI69paJwhSMJz7PPWjVP8Sjhclxmxmxv/RYI7ZOvR5BHX+ktH0we9gTWQMxcne8q1OY8xxz604gw==}
-    engines: {node: '>=12.7.0'}
-    peerDependencies:
-      '@types/react': '>=16.8'
-      immer: '>=9.0'
-      react: '>=16.8'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      immer:
-        optional: true
-      react:
-        optional: true
-    dependencies:
-      '@types/react': 18.3.1
-      react: 18.2.0
-      use-sync-external-store: 1.2.0(react@18.2.0)
-    dev: true
-
   /zustand@4.4.7(@types/react@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-QFJWJMdlETcI69paJwhSMJz7PPWjVP8Sjhclxmxmxv/RYI7ZOvR5BHX+ktH0we9gTWQMxcne8q1OY8xxz604gw==}
     engines: {node: '>=12.7.0'}
@@ -11409,6 +11391,25 @@ packages:
       react: 18.3.1
       use-sync-external-store: 1.2.0(react@18.3.1)
     dev: false
+
+  /zustand@4.5.2(@types/react@18.3.1)(react@18.2.0):
+    resolution: {integrity: sha512-2cN1tPkDVkwCy5ickKrI7vijSjPksFRfqS6237NzT0vqSsztTNnQdHw9mmN7uBdk3gceVXU0a+21jFzFzAc9+g==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      '@types/react': 18.3.1
+      react: 18.2.0
+      use-sync-external-store: 1.2.0(react@18.2.0)
 
   /zustand@4.5.2(@types/react@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-2cN1tPkDVkwCy5ickKrI7vijSjPksFRfqS6237NzT0vqSsztTNnQdHw9mmN7uBdk3gceVXU0a+21jFzFzAc9+g==}


### PR DESCRIPTION
When changing the browser window with a Portal component, it is distorting. This is due to a missmatch in the aspect ratio of the FBO and the camera used to render the FBA, which inherits the aspect ratio from the main canvas upon window resize.

To fix this, we set the aspect ratio to 1 before rendering to the FBO and reset it afterwards.

To test this, try the following setup and resize your browser window:

```javascript
<Canvas>
    <ambientLight intensity={0.5} />
     <Fullscreen>
         <Portal width={200} aspectRatio={1}>
              <mesh>
                   <boxGeometry />
                    <meshBasicMaterial color="red" />
               </mesh>
        </Portal>
    </Fullscreen>
</Canvas>
```

Note that there might be a better implementation that resizes the FBO dynamically rather than the updating the camera in useFrame.