### PR TITLE
fix: use lowercase eventnames in vanilla example and docs

### DIFF
--- a/docs/getting-started/vanilla.md
+++ b/docs/getting-started/vanilla.md
@@ -11,10 +11,10 @@ The vanilla version of uikit allows to build user interfaces with plain Three.js
 The vanilla version of uikit (`@pmndrs/uikit`) is decoupled from react. Therefore features such providing defaults via context is not available. Furthermore, no event system is available out of the box. For interactivity, such as hover effects, developers have to attach their own event system by emitting pointer events to the UI elements:
 
 ```js
-uiElement.dispatchEvent({ type: 'pointerOver', target: uiElement, nativeEvent: { pointerId: 1 } })
+uiElement.dispatchEvent({ type: 'pointerover', target: uiElement, nativeEvent: { pointerId: 1 } })
 ```
 
-Aside from interacitivty and contexts, every feature is available.
+Aside from interactivity and contexts, every feature is available.
 
 ## Building a user interface with `@pmndrs/uikit`
 

--- a/examples/vanilla/index.ts
+++ b/examples/vanilla/index.ts
@@ -45,7 +45,7 @@ const x = new Container({
   justifyContent: 'center',
   onSizeChange: console.log,
 })
-setTimeout(() => x.dispatchEvent({ type: 'pointerOver', target: x, nativeEvent: { pointerId: 1 } } as any), 0)
+setTimeout(() => x.dispatchEvent({ type: 'pointerover', target: x, nativeEvent: { pointerId: 1 } } as any), 0)
 const img = new Image({
   src: 'https://picsum.photos/300/300',
   borderRadius: 1000,


### PR DESCRIPTION
Between v0.3.4 and v0.3.5 the expected event names became lowercase when using vanilla Three.js (https://github.com/pmndrs/uikit/commit/9d52cc8ec96fac2167d997373c740c196e38bbbd). After updating this unexpectedly broke interactivity for those relying on the (old) documented convention (see #72).

To avoid further confusion, this PR updates the `vanilla.md` doc and `vanilla/index.ts` example to use the lower case variant.