### PR TITLE
[spike] make root optional in container

### DIFF
--- a/packages/react/src/container.tsx
+++ b/packages/react/src/container.tsx
@@ -1,7 +1,7 @@
 import { EventHandlers } from '@react-three/fiber/dist/declarations/src/core/events'
 import { forwardRef, ReactNode, RefAttributes, useEffect, useMemo, useRef } from 'react'
 import { Object3D } from 'three'
-import { ParentProvider, useParent } from './context.js'
+import { ParentProvider, useParent, useParentOptional } from './context.js'
 import { AddHandlers, usePropertySignals } from './utilts.js'
 import {
   ContainerProperties as BaseContainerProperties,
@@ -11,6 +11,7 @@ import {
   initialize,
 } from '@pmndrs/uikit/internals'
 import { ComponentInternals, useComponentInternals } from './ref.js'
+import { Root } from './root.js'
 
 export type ContainerProperties = {
   name?: string
@@ -18,7 +19,7 @@ export type ContainerProperties = {
 } & BaseContainerProperties &
   EventHandlers
 
-export const Container: (
+const ContainerInner: (
   props: ContainerProperties & RefAttributes<ComponentInternals<BaseContainerProperties & EventHandlers>>,
 ) => ReactNode = forwardRef((properties, ref) => {
   const parent = useParent()
@@ -55,5 +56,20 @@ export const Container: (
         <ParentProvider value={internals}>{properties.children}</ParentProvider>
       </object3D>
     </AddHandlers>
+  )
+})
+
+export const Container: (
+  props: ContainerProperties & RefAttributes<ComponentInternals<BaseContainerProperties & EventHandlers>>,
+) => ReactNode = forwardRef((properties, ref) => {
+  const parent = useParentOptional()
+  if (parent) {
+    return <ContainerInner {...properties} ref={ref} />
+  }
+
+  return (
+    <Root>
+      <ContainerInner {...properties} ref={ref} />
+    </Root>
   )
 })

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -11,4 +11,9 @@ export function useParent(): ParentContext {
   return parent
 }
 
+export function useParentOptional(): ParentContext {
+  const parent = useContext(ParentContext)
+  return parent
+}
+
 export const ParentProvider = ParentContext.Provider


### PR DESCRIPTION
Hey @bbohlender here's a quick spike to test the waters. We'd conditionally render `<Root>` if it's missing in what we'd consider "top level components".

Should that be all components? If you have a list that should be changed and are happy with the approach I can do it all, add tests, and get it into a mergeable state.