### PR TITLE
fix: default slider using unknown point field

### DIFF
--- a/packages/kits/default/src/slider.tsx
+++ b/packages/kits/default/src/slider.tsx
@@ -42,7 +42,7 @@ export const Slider: (props: SliderProperties & RefAttributes<ComponentInternals
         if (internalRef.current == null) {
           return
         }
-        vectorHelper.copy(e.point)
+        vectorHelper.copy(e.unprojectedPoint)
         internalRef.current.interactionPanel.worldToLocal(vectorHelper)
         const minValue = readReactive(min)
         const maxValue = readReactive(max)


### PR DESCRIPTION
Changes the default slider to use IntersectionEvent's unprojectedPoint. I'm not sure where .point came from - this was causing the later usage of vectorHelper.x to be a NaN which killed the render. This works as expected in my setup.