### PR TITLE
fix: prevent input element from creating a gap at bottom of page in Firefox

### DIFF
--- a/packages/uikit/src/components/input.ts
+++ b/packages/uikit/src/components/input.ts
@@ -370,6 +370,7 @@ export function createHtmlInputElement(
     const style = element.style
     style.setProperty('position', 'absolute')
     style.setProperty('left', '-1000vw')
+    style.setProperty('top', '0')
     style.setProperty('pointerEvents', 'none')
     style.setProperty('opacity', '0')
     element.addEventListener('input', () => {


### PR DESCRIPTION
Fixes #95 

Unlike what I initially thought the `display` type `inline-block` and `block` have no bearing on this behaviour. This PR instead adds the `top` style property, which effectively guarantee the hidden input element won't create a gap at the bottom of the page.