### PR TITLE
Update lucide dependency automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # Maintain dependencies for lucide.
+  - package-ecosystem: "npm"
+    directory: "packages/icons/lucide"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "08:00"
+      timezone: "America/New_York"
+    reviewers:
+      - "bbohlender"
+    groups:
+      development:
+        dependency-type: development
+        patterns:
+          - "*"


### PR DESCRIPTION
We love using lucide through uikit, but it's fairly outdated. To spare you the hassle @bbohlender, I figured automatic updates would make it easier for you to maintain all the dependencies. I would also recommend adding the other packages as well, but since I am not sure how you like to do the grouping I think it would be better to leave it up to you. This PR allows for edits by the maintainers, so you are welcome to fit to your needs :)