### PR TITLE
chore: using pmndrs/docs v2

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   docs:
-    uses: pmndrs/docs/.github/workflows/build.yml@v1
+    uses: pmndrs/docs/.github/workflows/build.yml@v2
     with:
-      mdx: './docs'
+      mdx: 'docs'
       libname: 'uikit'
       base_path: '/uikit/docs'
       icon: '🎨'


### PR DESCRIPTION
mdx should no longer start with ./ in v2