### PR TITLE
fix: Update video properties on suspended element

### DIFF
--- a/packages/react/src/suspending.tsx
+++ b/packages/react/src/suspending.tsx
@@ -1,10 +1,11 @@
-import { ReactNode, RefAttributes, forwardRef, useEffect, useMemo } from 'react'
+import { ReactNode, RefAttributes, forwardRef } from 'react'
 import { Image, ImageProperties } from './image.js'
 import { useLoader } from '@react-three/fiber'
 import { SRGBColorSpace, TextureLoader } from 'three'
 import { ComponentInternals } from './ref.js'
 import { Video, VideoProperties, VideoRef } from './video.js'
 import { suspend } from 'suspend-react'
+import { updateVideoElement } from '@pmndrs/uikit/internals'
 
 export type SuspendingImageProperties = ImageProperties & {
   src: string
@@ -34,6 +35,7 @@ const loadVideoElementSymbol = Symbol('load-video-element')
 export const SuspendingVideo: (props: SuspendingVideoProperties & RefAttributes<VideoRef>) => ReactNode = forwardRef(
   ({ src, ...props }, ref) => {
     const element = suspend(loadVideoElement, [src, loadVideoElementSymbol])
+    updateVideoElement(element, props)
     return <Video ref={ref} src={element} {...props} />
   },
 )

--- a/packages/react/src/video.tsx
+++ b/packages/react/src/video.tsx
@@ -76,7 +76,9 @@ export const Video: (props: VideoProperties & RefAttributes<VideoRef>) => ReactN
     const invalidate = useThree((s) => s.invalidate)
     useEffect(() => setupVideoElementInvalidation(element, invalidate), [element, invalidate])
 
-    updateVideoElement(element, props)
+    if (!(props.src instanceof HTMLVideoElement)) {
+      updateVideoElement(element, props)
+    }
 
     useEffect(() => {
       const updateAspectRatio = () => (aspectRatio.value = element.videoWidth / element.videoHeight)

--- a/packages/uikit/src/components/video.ts
+++ b/packages/uikit/src/components/video.ts
@@ -25,10 +25,6 @@ export function updateVideoElement(
   element: HTMLVideoElement,
   { src, autoplay, loop, muted, playbackRate, preservesPitch, volume, crossOrigin }: InternalVideoProperties,
 ) {
-  if (src instanceof HTMLElement) {
-    return
-  }
-
   element.playsInline = true
   element.volume = volume ?? 1
   element.preservesPitch = preservesPitch ?? true

--- a/packages/uikit/src/vanilla/video.ts
+++ b/packages/uikit/src/vanilla/video.ts
@@ -19,7 +19,9 @@ export class Video<T = {}, EM extends ThreeEventMap = ThreeEventMap> extends Ima
 
   constructor(props: VideoProperties<EM>, defaultProperties?: AllOptionalProperties) {
     const element = props.src instanceof HTMLVideoElement ? props.src : document.createElement('video')
-    updateVideoElement(element, props)
+    if (!(props.src instanceof HTMLVideoElement)) {
+      updateVideoElement(element, props)
+    }
     const texture = new VideoTexture(element)
     texture.needsUpdate = true
     const aspectRatio = signal<number>(1)
@@ -42,7 +44,9 @@ export class Video<T = {}, EM extends ThreeEventMap = ThreeEventMap> extends Ima
   }
 
   setProperties(props: VideoProperties<EM> & ImageProperties<EM>): void {
-    updateVideoElement(this.element, props)
+    if (!(props.src instanceof HTMLVideoElement)) {
+      updateVideoElement(this.element, props)
+    }
     super.setProperties({
       aspectRatio: this.aspectRatio,
       ...props,


### PR DESCRIPTION
The suspending video is taking a src as string and creating its own html video element and passing it as src into the video compent. The video compent has an `updateVideoElement` function to set the props of the element iff the src attribute is a string. However, since we pass in an element, the properties will never be set.
Calling this function before we pass it to the video component should fix it.

Towards https://github.com/pmndrs/uikit/issues/179