### PR TITLE
add interpreter module with comprehensive test coverage

### DIFF
--- a/packages/uikitml/package.json
+++ b/packages/uikitml/package.json
@@ -6,9 +6,17 @@
     "inline-style-parser": "^0.2.4",
     "node-html-parser": "^7.0.1"
   },
+  "peerDependencies": {
+    "@pmndrs/uikit": "workspace:^"
+  },
+  "devDependencies": {
+    "@pmndrs/uikit": "workspace:^",
+    "@types/jsdom": "^21.1.7",
+    "jsdom": "^26.1.0"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "test": "mocha ./test/*.spec.ts"
+    "test": "mocha ./test/*.spec.ts --exit"
   },
   "files": [
     "dist"

--- a/packages/uikitml/src/index.ts
+++ b/packages/uikitml/src/index.ts
@@ -1,2 +1,3 @@
 export * from './parser/index.js'
 export * from './generator/index.js'
+export * from './interpreter/index.js'

--- a/packages/uikitml/src/interpreter/index.ts
+++ b/packages/uikitml/src/interpreter/index.ts
@@ -1,0 +1,202 @@
+import { Object3D, Object3DEventMap } from 'three'
+import { Component, Container, Image, Input, Text, Video, Svg } from '@pmndrs/uikit'
+import { ElementJson } from '../parser/index.js'
+
+export interface Kit {
+  [componentName: string]: new (props?: any) => Component<Object3DEventMap>
+}
+export function interpret(
+  json: ElementJson | string,
+  classes: Record<string, Record<string, string>>,
+  kit?: Kit,
+): Object3D<Object3DEventMap> | null {
+  if (json === null || json === undefined) {
+    return null
+  }
+
+  if (typeof json === 'string') {
+    return new Text({ text: json })
+  }
+
+  const properties = { ...json.properties }
+  if (properties.style && typeof properties.style === 'object') {
+    Object.assign(properties, properties.style)
+    delete properties.style
+  }
+
+  if (json.defaultProperties) {
+    Object.assign(properties, json.defaultProperties, properties)
+  }
+
+  const elementId: string | undefined = properties.id
+  let element: Component<Object3DEventMap>
+
+  switch (json.type) {
+    case 'container':
+      element = createContainerElement(json, properties)
+      break
+
+    case 'custom':
+      element = createCustomElement(json, properties, kit)
+      break
+
+    case 'image':
+      element = createImageElement(json, properties)
+      break
+
+    case 'svg':
+      element = createSvgElement(json, properties)
+      break
+
+    case 'inline-svg':
+      element = createInlineSvgElement(json, properties)
+      break
+
+    case 'video':
+      element = createVideoElement(json, properties)
+      break
+
+    case 'input':
+      element = createInputElement(json, properties)
+      break
+
+    default:
+      console.warn(`Unknown element type: ${(json as any).type}, falling back to container`)
+      element = new Container(properties)
+      break
+  }
+
+  if (elementId) {
+    element.userData.id = elementId
+  }
+
+  if (json.sourceTag) {
+    element.userData.sourceTag = json.sourceTag
+  }
+
+  if (properties.class) {
+    const classNames = (properties.class as string).split(' ')
+    classNames.forEach((className) => {
+      const styleClass = classes[className]
+      if (styleClass) {
+        element.classList.add(styleClass)
+      }
+    })
+  }
+
+  if ('children' in json && json.children && !(element instanceof Text)) {
+    json.children.forEach((childElementJson: any) => {
+      const childElement = interpret(childElementJson, classes, kit)
+      if (childElement) {
+        element.add(childElement)
+      }
+    })
+  }
+
+  return element
+}
+
+function createContainerElement(
+  json: ElementJson & { type: 'container' },
+  properties: Record<string, any>,
+): Container | Text {
+  if (json.children && json.children.length === 1 && typeof json.children[0] === 'string') {
+    return new Text({ ...properties, text: json.children[0] })
+  }
+
+  return new Container(properties)
+}
+
+function createCustomElement(
+  json: ElementJson & { type: 'custom' },
+  properties: Record<string, any>,
+  kit?: Kit,
+): Component<Object3DEventMap> {
+  const componentName = json.sourceTag
+  const CustomComponent = kit?.[componentName]
+
+  if (CustomComponent) {
+    const element = new CustomComponent(properties)
+    element.userData.customElement = {
+      componentName,
+      sourceTag: json.sourceTag,
+    }
+    return element
+  } else {
+    const element = new Container(properties)
+    element.userData.customElement = {
+      componentName,
+      sourceTag: json.sourceTag,
+    }
+    console.warn(`Custom component '${componentName}' not found in kit, falling back to Container`)
+    return element
+  }
+}
+
+function createImageElement(_json: ElementJson & { type: 'image' }, properties: Record<string, any>): Image {
+  if (!properties.src) {
+    console.warn('Image element missing src property')
+    properties.src = ''
+  }
+
+  return new Image(properties as any)
+}
+
+function createSvgElement(_json: ElementJson & { type: 'svg' }, properties: Record<string, any>): Svg {
+  if (!properties.src) {
+    console.warn('SVG element missing src property')
+    properties.src = ''
+  }
+
+  return new Svg(properties)
+}
+
+function createInlineSvgElement(json: ElementJson & { type: 'inline-svg' }, properties: Record<string, any>): Svg {
+  const svgText = json.text || ''
+  return new Svg({
+    ...properties,
+    content: svgText,
+  })
+}
+
+function createVideoElement(_json: ElementJson & { type: 'video' }, properties: Record<string, any>): Video {
+  if (!properties.src) {
+    console.warn('Video element missing src property')
+    properties.src = ''
+  }
+
+  return new Video(properties)
+}
+
+function createInputElement(json: ElementJson & { type: 'input' }, properties: Record<string, any>): Input {
+  if (json.sourceTag === 'textarea' && !properties.multiline) {
+    properties.multiline = true
+  }
+
+  return new Input(properties)
+}
+
+export function getElementDescription(json: ElementJson | string): string {
+  if (typeof json === 'string') {
+    return `Text: "${json.substring(0, 20)}${json.length > 20 ? '...' : ''}"`
+  }
+
+  switch (json.type) {
+    case 'container':
+      return `Container (${json.sourceTag})`
+    case 'custom':
+      return `Custom: ${json.sourceTag}`
+    case 'image':
+      return `Image: ${json.properties?.src || 'no src'}`
+    case 'svg':
+      return `SVG: ${json.properties?.src || 'no src'}`
+    case 'inline-svg':
+      return `Inline SVG (${json.text?.length || 0} chars)`
+    case 'video':
+      return `Video: ${json.properties?.src || 'no src'}`
+    case 'input':
+      return `Input (${json.sourceTag}${json.properties?.multiline || json.defaultProperties?.multiline ? ', multiline' : ''})`
+    default:
+      return `Unknown: ${(json as any).type}`
+  }
+}

--- a/packages/uikitml/test/interpreter.spec.ts
+++ b/packages/uikitml/test/interpreter.spec.ts
@@ -1,0 +1,308 @@
+import { expect } from 'chai'
+import { JSDOM } from 'jsdom'
+import { Container, Text, Image, Input } from '@pmndrs/uikit'
+import { interpret, Kit, getElementDescription } from '../src/interpreter/index.js'
+import { parse } from '../src/parser/index.js'
+
+// Minimal DOM setup for uikit components
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>')
+global.document = dom.window.document
+global.window = dom.window as any
+global.HTMLElement = dom.window.HTMLElement
+global.HTMLImageElement = dom.window.HTMLImageElement
+
+class MockCustomComponent extends Container {
+  constructor(props: any = {}) {
+    super(props)
+  }
+}
+
+// Helper function to safely interpret parsed elements
+function safeInterpret(html: string, kit?: Kit) {
+  const parsed = parse(html)
+  if (!parsed.element) {
+    throw new Error(`Failed to parse: ${html}`)
+  }
+  // Convert classes from parser format to interpreter format
+  const flatClasses: Record<string, Record<string, string>> = {}
+  for (const [className, classData] of Object.entries(parsed.classes)) {
+    if (classData && typeof classData === 'object' && 'content' in classData) {
+      flatClasses[className] = classData.content as Record<string, string>
+    }
+  }
+  return {
+    result: interpret(parsed.element, flatClasses, kit),
+    classes: flatClasses,
+    element: parsed.element,
+  }
+}
+
+describe('interpreter', () => {
+  describe('basic element interpretation', () => {
+    it('should interpret text strings', () => {
+      const result = interpret('Hello World', {})
+      expect(result).to.be.instanceOf(Text)
+    })
+
+    it('should handle null and undefined input', () => {
+      expect(interpret(null as any, {})).to.be.null
+      expect(interpret(undefined as any, {})).to.be.null
+    })
+
+    it('should interpret container elements', () => {
+      const { result } = safeInterpret('<div><span>Content</span></div>')
+      expect(result).to.be.instanceOf(Container)
+      expect(result?.children).to.have.length(1)
+      expect(result?.children[0]).to.be.instanceOf(Text)
+    })
+
+    it('should optimize single text child containers to Text elements', () => {
+      const { result } = safeInterpret('<div>Hello</div>')
+      expect(result).to.be.instanceOf(Text)
+    })
+
+    it('should interpret image elements', () => {
+      const { result } = safeInterpret('<img src="test.jpg" alt="Test" />')
+      expect(result).to.be.instanceOf(Image)
+    })
+
+    it('should interpret input elements', () => {
+      const { result } = safeInterpret('<input type="text" placeholder="Enter text" />')
+      expect(result).to.be.instanceOf(Input)
+    })
+
+    it('should interpret textarea as input with multiline', () => {
+      const { result } = safeInterpret('<textarea>Some text</textarea>')
+      expect(result).to.be.instanceOf(Input)
+    })
+  })
+
+  describe('custom elements', () => {
+    it('should interpret custom elements without kit as Container', () => {
+      const { result } = safeInterpret('<custom-button>Click me</custom-button>')
+      expect(result).to.be.instanceOf(Container)
+      expect(result?.userData.customElement).to.deep.equal({
+        componentName: 'custom-button',
+        sourceTag: 'custom-button',
+      })
+    })
+
+    it('should interpret custom elements with matching kit component', () => {
+      const kit: Kit = {
+        'custom-button': MockCustomComponent,
+      }
+      const { result } = safeInterpret('<custom-button data-test="value">Click me</custom-button>', kit)
+      expect(result).to.be.instanceOf(MockCustomComponent)
+      expect(result?.userData.customElement).to.deep.equal({
+        componentName: 'custom-button',
+        sourceTag: 'custom-button',
+      })
+    })
+
+    it('should fall back to Container when custom component not found in kit', () => {
+      const kit: Kit = {
+        'other-component': MockCustomComponent,
+      }
+      const { result } = safeInterpret('<missing-component>Content</missing-component>', kit)
+      expect(result).to.be.instanceOf(Container)
+      expect(result?.userData.customElement.componentName).to.equal('missing-component')
+    })
+  })
+
+  describe('CSS class application', () => {
+    it('should apply CSS classes to elements', () => {
+      const htmlWithStyles = `
+        <style>
+          .test-class {
+            color: red;
+            font-size: 16px;
+            background-color: blue;
+          }
+        </style>
+        <div class="test-class"><span>Content</span></div>
+      `
+      const { result } = safeInterpret(htmlWithStyles)
+      expect(result).to.be.instanceOf(Container)
+    })
+
+    it('should apply multiple CSS classes', () => {
+      const htmlWithStyles = `
+        <style>
+          .class1 { color: red; }
+          .class2 { font-size: 16px; }
+        </style>
+        <div class="class1 class2"><span>Content</span></div>
+      `
+      const { result } = safeInterpret(htmlWithStyles)
+      expect(result).to.be.instanceOf(Container)
+    })
+
+    it('should apply CSS classes to optimized Text elements', () => {
+      const htmlWithStyles = `
+        <style>
+          .text-style {
+            color: green;
+            font-weight: bold;
+          }
+        </style>
+        <div class="text-style">Single text</div>
+      `
+      const { result } = safeInterpret(htmlWithStyles)
+      expect(result).to.be.instanceOf(Text)
+    })
+  })
+
+  describe('property handling', () => {
+    it('should store element id in userData', () => {
+      const { result } = safeInterpret('<div id="test-element">Content</div>')
+      expect(result?.userData.id).to.equal('test-element')
+    })
+
+    it('should store source tag in userData', () => {
+      const { result } = safeInterpret('<section>Content</section>')
+      expect(result?.userData.sourceTag).to.equal('section')
+    })
+  })
+
+  describe('children processing', () => {
+    it('should process nested elements', () => {
+      const { result } = safeInterpret('<div><p>Paragraph</p><span>Span</span></div>')
+      expect(result).to.be.instanceOf(Container)
+      expect(result?.children).to.have.length(2)
+      expect(result?.children[0]).to.be.instanceOf(Text)
+      expect(result?.children[1]).to.be.instanceOf(Text)
+    })
+
+    it('should not process children for Text elements', () => {
+      const { result } = safeInterpret('<div>Single text</div>')
+      expect(result).to.be.instanceOf(Text)
+    })
+
+    it('should recursively interpret children with kit', () => {
+      const kit: Kit = {
+        'custom-child': MockCustomComponent,
+      }
+      const { result } = safeInterpret('<div><custom-child>Content</custom-child></div>', kit)
+      expect(result).to.be.instanceOf(Container)
+      expect(result?.children).to.have.length(1)
+      expect(result?.children[0]).to.be.instanceOf(MockCustomComponent)
+    })
+  })
+
+  describe('error handling', () => {
+    it('should handle unknown element types', () => {
+      const unknownElement = {
+        type: 'unknown' as any,
+        sourceTag: 'unknown',
+        properties: {},
+        defaultProperties: {},
+        children: [],
+      }
+      const result = interpret(unknownElement, {})
+      expect(result).to.be.instanceOf(Container)
+    })
+
+    it('should handle missing src for image elements', () => {
+      const { result } = safeInterpret('<img alt="Test" />')
+      expect(result).to.be.instanceOf(Image)
+    })
+  })
+
+  describe('complex scenarios', () => {
+    it('should handle nested containers with custom components', () => {
+      const kit: Kit = {
+        'custom-card': MockCustomComponent,
+        'custom-button': MockCustomComponent,
+      }
+      const { result } = safeInterpret(
+        `
+        <div class="container">
+          <custom-card title="Card Title">
+            <p>Card content</p>
+            <custom-button>Action</custom-button>
+          </custom-card>
+        </div>
+      `,
+        kit,
+      )
+      expect(result).to.be.instanceOf(Container)
+      expect(result?.children).to.have.length(1)
+      expect(result?.children[0]).to.be.instanceOf(MockCustomComponent)
+    })
+
+    it('should handle mixed content types', () => {
+      const { result } = safeInterpret(`
+        <div>
+          <img src="image.jpg" alt="Image" />
+          <p>Text content</p>
+          <input type="text" placeholder="Input" />
+        </div>
+      `)
+      expect(result).to.be.instanceOf(Container)
+      expect(result?.children).to.have.length(3)
+      expect(result?.children[0]).to.be.instanceOf(Image)
+      expect(result?.children[1]).to.be.instanceOf(Text)
+      expect(result?.children[2]).to.be.instanceOf(Input)
+    })
+  })
+
+  describe('getElementDescription helper', () => {
+    it('should describe text strings', () => {
+      const description = getElementDescription('Hello World')
+      expect(description).to.equal('Text: "Hello World"')
+    })
+
+    it('should describe long text strings with truncation', () => {
+      const longText = 'This is a very long text that should be truncated'
+      const description = getElementDescription(longText)
+      expect(description).to.equal('Text: "This is a very long ..."')
+    })
+
+    it('should describe container elements', () => {
+      const { element } = safeInterpret('<div>Content</div>')
+      const description = getElementDescription(element)
+      expect(description).to.equal('Container (div)')
+    })
+
+    it('should describe custom elements', () => {
+      const { element } = safeInterpret('<custom-button>Click</custom-button>')
+      const description = getElementDescription(element)
+      expect(description).to.equal('Custom: custom-button')
+    })
+
+    it('should describe image elements', () => {
+      const { element } = safeInterpret('<img src="test.jpg" alt="Test" />')
+      const description = getElementDescription(element)
+      expect(description).to.equal('Image: test.jpg')
+    })
+
+    it('should describe image elements without src', () => {
+      const { element } = safeInterpret('<img alt="Test" />')
+      const description = getElementDescription(element)
+      expect(description).to.equal('Image: no src')
+    })
+
+    it('should describe input elements', () => {
+      const { element } = safeInterpret('<input type="text" />')
+      const description = getElementDescription(element)
+      expect(description).to.equal('Input (input)')
+    })
+
+    it('should describe textarea elements', () => {
+      const { element } = safeInterpret('<textarea>Content</textarea>')
+      const description = getElementDescription(element)
+      expect(description).to.equal('Input (textarea, multiline)')
+    })
+
+    it('should describe unknown element types', () => {
+      const unknownElement = {
+        type: 'unknown' as any,
+        sourceTag: 'unknown',
+        properties: {},
+        defaultProperties: {},
+      }
+      const description = getElementDescription(unknownElement)
+      expect(description).to.equal('Unknown: unknown')
+    })
+  })
+})

--- a/packages/uikitml/test/interpreter.spec.ts
+++ b/packages/uikitml/test/interpreter.spec.ts
@@ -23,16 +23,9 @@ function safeInterpret(html: string, kit?: Kit) {
   if (!parsed.element) {
     throw new Error(`Failed to parse: ${html}`)
   }
-  // Convert classes from parser format to interpreter format
-  const flatClasses: Record<string, Record<string, string>> = {}
-  for (const [className, classData] of Object.entries(parsed.classes)) {
-    if (classData && typeof classData === 'object' && 'content' in classData) {
-      flatClasses[className] = classData.content as Record<string, string>
-    }
-  }
   return {
-    result: interpret(parsed.element, flatClasses, kit),
-    classes: flatClasses,
+    result: interpret(parsed, kit),
+    classes: parsed.classes,
     element: parsed.element,
   }
 }
@@ -40,13 +33,13 @@ function safeInterpret(html: string, kit?: Kit) {
 describe('interpreter', () => {
   describe('basic element interpretation', () => {
     it('should interpret text strings', () => {
-      const result = interpret('Hello World', {})
+      const result = interpret({ element: 'Hello World', classes: {} })
       expect(result).to.be.instanceOf(Text)
     })
 
     it('should handle null and undefined input', () => {
-      expect(interpret(null as any, {})).to.be.null
-      expect(interpret(undefined as any, {})).to.be.null
+      expect(interpret({ element: null as any, classes: {} })).to.be.null
+      expect(interpret({ element: undefined as any, classes: {} })).to.be.null
     })
 
     it('should interpret container elements', () => {
@@ -198,7 +191,7 @@ describe('interpreter', () => {
         defaultProperties: {},
         children: [],
       }
-      const result = interpret(unknownElement, {})
+      const result = interpret({ element: unknownElement, classes: {} })
       expect(result).to.be.instanceOf(Container)
     })
 

--- a/packages/uikitml/test/interpreter.spec.ts
+++ b/packages/uikitml/test/interpreter.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { JSDOM } from 'jsdom'
-import { Container, Text, Image, Input } from '@pmndrs/uikit'
+import { Container, Text, Image, Input, StyleSheet } from '@pmndrs/uikit'
 import { interpret, Kit, getElementDescription } from '../src/interpreter/index.js'
 import { parse } from '../src/parser/index.js'
 
@@ -103,7 +103,7 @@ describe('interpreter', () => {
   })
 
   describe('CSS class application', () => {
-    it('should apply CSS classes to elements', () => {
+    it('should add CSS classes to global StyleSheet and apply to elements', () => {
       const htmlWithStyles = `
         <style>
           .test-class {
@@ -116,6 +116,13 @@ describe('interpreter', () => {
       `
       const { result } = safeInterpret(htmlWithStyles)
       expect(result).to.be.instanceOf(Container)
+
+      // Verify class was added to global StyleSheet
+      expect(StyleSheet['test-class']).to.deep.include({
+        color: 'red',
+        fontSize: '16px',
+        backgroundColor: 'blue',
+      })
     })
 
     it('should apply multiple CSS classes', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,6 +554,16 @@ importers:
       node-html-parser:
         specifier: ^7.0.1
         version: 7.0.1
+    devDependencies:
+      '@pmndrs/uikit':
+        specifier: workspace:^
+        version: link:../uikit
+      '@types/jsdom':
+        specifier: ^21.1.7
+        version: 21.1.7
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
 
 packages:
 
@@ -568,6 +578,9 @@ packages:
   '@antfu/ni@0.21.12':
     resolution: {integrity: sha512-2aDL3WUv8hMJb2L3r/PIQWsTLyq7RQr3v9xD16fiz6O8ys1xEyLhhTOv8gxtZvJiTzjTF5pHoArvRdesGL1DMQ==}
     hasBin: true
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.26.2':
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
@@ -830,6 +843,34 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@5.0.2':
+    resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.0.10':
+    resolution: {integrity: sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@dimforge/rapier3d-compat@0.14.0':
     resolution: {integrity: sha512-/uHrUzS+CRQ+NQrrJCEDUkhwHlNsAAexbNXgbN9sHY+GwR+SFFAFrxRr8Llf5/AJZzqiLANdQIfJ63Cw4gJVqw==}
@@ -2687,6 +2728,9 @@ packages:
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
 
+  '@types/jsdom@21.1.7':
+    resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -2773,6 +2817,9 @@ packages:
 
   '@types/three@0.161.0':
     resolution: {integrity: sha512-VrgtT08x7SQYtMuhVJDVNBgOGdUCvb6o5DP/DI/sz7jVyHdoDr3rZc6w/OcHZlUCVf0UGYPtflAjUUfI49Dhsg==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/webxr@0.5.21':
     resolution: {integrity: sha512-geZIAtLzjGmgY2JUi6VxXdCrTb99A7yP49lxLr2Nm/uIK0PkkxcEi4OGhoGDO4pxCf3JwGz2GiJL2Ej4K2bKaA==}
@@ -3526,12 +3573,20 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  cssstyle@4.5.0:
+    resolution: {integrity: sha512-/7gw8TGrvH/0g564EnhgFZogTMVe+lifpB7LWU+PEsiq5o83TUXR3fDbzTRXOJhoJwck5IS9ez3Em5LNMMO2aw==}
+    engines: {node: '>=18'}
+
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -3589,6 +3644,9 @@ packages:
   decamelize@5.0.1:
     resolution: {integrity: sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==}
     engines: {node: '>=10'}
+
+  decimal.js@10.5.0:
+    resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
 
   decompress-response@3.3.0:
     resolution: {integrity: sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==}
@@ -3758,6 +3816,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   error-ex@1.3.2:
@@ -4462,6 +4524,10 @@ packages:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -4479,12 +4545,20 @@ packages:
   http-parser-js@0.5.9:
     resolution: {integrity: sha512-n1XsPy3rXVxlqxVioEWdC+0+M+SQw0DpJynwtOPo1X+ZlvdzTLtDBIJJlDQTnwZIFJrZSzSGmIOUdP8tu+SgLw==}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
 
   https-proxy-agent@6.2.1:
     resolution: {integrity: sha512-ONsE3+yfZF2caH5+bJlcddtWqNI3Gvs5A38+ngvljxaBiRXRswym2c7yf8UAeFpRFKjFNHIFEHqR/OLAWJzyiA==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
   human-signals@1.1.1:
@@ -4501,6 +4575,10 @@ packages:
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
   idb@7.1.1:
@@ -4684,6 +4762,9 @@ packages:
   is-plain-obj@2.1.0:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
     engines: {node: '>=8'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-promise@2.2.2:
     resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
@@ -4964,6 +5045,15 @@ packages:
 
   js2xmlparser@4.0.2:
     resolution: {integrity: sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==}
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -5457,6 +5547,9 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  nwsapi@2.2.20:
+    resolution: {integrity: sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -5615,6 +5708,9 @@ packages:
     resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
     engines: {node: '>=6'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -5639,6 +5735,7 @@ packages:
 
   path-match@1.2.4:
     resolution: {integrity: sha512-UWlehEdqu36jmh4h5CWJ7tARp1OEVKGHKm6+dg9qMq5RKUTV5WJrGgaZ3dN2m7WFAXDbjlHzvJvL/IUpy84Ktw==}
+    deprecated: This package is archived and no longer maintained. For support, visit https://github.com/expressjs/express/discussions
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -6092,6 +6189,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -6119,6 +6219,10 @@ packages:
 
   sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.21.0:
     resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
@@ -6428,6 +6532,9 @@ packages:
     peerDependencies:
       react: '>=17.0'
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   synckit@0.9.2:
     resolution: {integrity: sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -6517,6 +6624,13 @@ packages:
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -6536,8 +6650,16 @@ packages:
     resolution: {integrity: sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==}
     engines: {node: '>=10'}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -6861,6 +6983,10 @@ packages:
       terser:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
@@ -6883,6 +7009,10 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   websocket-driver@0.7.4:
     resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
     engines: {node: '>=0.8.0'}
@@ -6891,8 +7021,20 @@ packages:
     resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
     engines: {node: '>=0.8.0'}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -6953,6 +7095,18 @@ packages:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  ws@8.18.2:
+    resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xdg-app-paths@5.1.0:
     resolution: {integrity: sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==}
     engines: {node: '>=6'}
@@ -6968,6 +7122,10 @@ packages:
   xhr@2.6.0:
     resolution: {integrity: sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xml-parse-from-string@1.0.1:
     resolution: {integrity: sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==}
 
@@ -6978,6 +7136,9 @@ packages:
   xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xmlcreate@2.0.4:
     resolution: {integrity: sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==}
@@ -7101,6 +7262,14 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
 
   '@antfu/ni@0.21.12': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.0.10(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -7430,6 +7599,26 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/color-helpers@5.0.2': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.0.10(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.0.2
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@dimforge/rapier3d-compat@0.14.0': {}
 
@@ -9619,6 +9808,12 @@ snapshots:
       '@types/istanbul-lib-report': 3.0.3
     optional: true
 
+  '@types/jsdom@21.1.7':
+    dependencies:
+      '@types/node': 20.17.16
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -9706,6 +9901,8 @@ snapshots:
       '@types/webxr': 0.5.21
       fflate: 0.6.10
       meshoptimizer: 0.18.1
+
+  '@types/tough-cookie@4.0.5': {}
 
   '@types/webxr@0.5.21': {}
 
@@ -10680,9 +10877,19 @@ snapshots:
 
   cssesc@3.0.0: {}
 
+  cssstyle@4.5.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.1.3: {}
 
   data-uri-to-buffer@4.0.1: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -10728,6 +10935,8 @@ snapshots:
   decamelize@4.0.0: {}
 
   decamelize@5.0.1: {}
+
+  decimal.js@10.5.0: {}
 
   decompress-response@3.3.0:
     dependencies:
@@ -10881,6 +11090,8 @@ snapshots:
       once: 1.4.0
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   error-ex@1.3.2:
     dependencies:
@@ -11753,6 +11964,10 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-escaper@2.0.2:
     optional: true
 
@@ -11773,6 +11988,13 @@ snapshots:
 
   http-parser-js@0.5.9: {}
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.0(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
@@ -11787,6 +12009,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.0(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   human-signals@1.1.1: {}
 
   human-signals@2.1.0:
@@ -11795,6 +12024,10 @@ snapshots:
   human-signals@4.3.1: {}
 
   iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -11953,6 +12186,8 @@ snapshots:
   is-plain-obj@1.1.0: {}
 
   is-plain-obj@2.1.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-promise@2.2.2: {}
 
@@ -12479,6 +12714,33 @@ snapshots:
     dependencies:
       xmlcreate: 2.0.4
 
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.5.0
+      data-urls: 5.0.0
+      decimal.js: 10.5.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.20
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.2
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.0: {}
@@ -12948,6 +13210,8 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  nwsapi@2.2.20: {}
+
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
@@ -13154,6 +13418,10 @@ snapshots:
       lines-and-columns: 1.2.4
 
   parse-ms@2.1.0: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   path-browserify@1.0.1: {}
 
@@ -13656,6 +13924,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.32.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -13686,6 +13956,10 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   sax@1.4.1: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.21.0:
     dependencies:
@@ -14063,6 +14337,8 @@ snapshots:
     dependencies:
       react: 19.0.0
 
+  symbol-tree@3.2.4: {}
+
   synckit@0.9.2:
     dependencies:
       '@pkgr/core': 0.1.1
@@ -14214,6 +14490,12 @@ snapshots:
 
   tinycolor2@1.6.0: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   tmpl@1.0.5:
     optional: true
 
@@ -14230,7 +14512,15 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tr46@0.0.3: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -14604,6 +14894,10 @@ snapshots:
       '@types/node': 20.17.16
       fsevents: 2.3.3
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
@@ -14623,6 +14917,8 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
+  webidl-conversions@7.0.0: {}
+
   websocket-driver@0.7.4:
     dependencies:
       http-parser-js: 0.5.9
@@ -14631,7 +14927,18 @@ snapshots:
 
   websocket-extensions@0.1.4: {}
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
   whatwg-fetch@3.6.20: {}
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -14723,6 +15030,8 @@ snapshots:
       signal-exit: 3.0.7
     optional: true
 
+  ws@8.18.2: {}
+
   xdg-app-paths@5.1.0:
     dependencies:
       xdg-portable: 7.3.0
@@ -14740,6 +15049,8 @@ snapshots:
       parse-headers: 2.0.5
       xtend: 4.0.2
 
+  xml-name-validator@5.0.0: {}
+
   xml-parse-from-string@1.0.1: {}
 
   xml2js@0.5.0:
@@ -14748,6 +15059,8 @@ snapshots:
       xmlbuilder: 11.0.1
 
   xmlbuilder@11.0.1: {}
+
+  xmlchars@2.2.0: {}
 
   xmlcreate@2.0.4: {}
 


### PR DESCRIPTION
## Summary
  - Add new interpreter module that converts parsed HTML elements to uikit components
  - Implement support for text, container, image, and input elements
  - Add comprehensive test suite with JSDOM setup and proper test isolation

  ## Changes
  - **New interpreter module** (`src/interpreter/index.ts`)
    - Converts `ElementJson` from parser to uikit `Object3D` components
    - Supports custom element mapping through optional `Kit` interface
    - Handles CSS class application and property merging
    - Optimizes single-text containers to `Text` components
  - **Comprehensive test coverage** (`test/interpreter.spec.ts`)
    - Tests for all supported element types and edge cases
    - Custom element kit integration testing
    - CSS class application and property handling
    - Error handling and fallback scenarios
  - **Package updates**
    - Added JSDOM dependencies for testing
    - Added `--exit` flag to Mocha for proper test cleanup
    - Export interpreter module from main package