### PR TITLE
Make RadioGroupItem in default kit value optional

### DIFF
--- a/packages/kits/default/src/radio-group.tsx
+++ b/packages/kits/default/src/radio-group.tsx
@@ -39,7 +39,7 @@ export const RadioGroup: (props: RadioGroupProperties & RefAttributes<ContainerR
   },
 )
 
-export type RadioGroupItemProperties = ContainerProperties & { disabled?: boolean; value: string }
+export type RadioGroupItemProperties = ContainerProperties & { disabled?: boolean; value?: string }
 
 export const RadioGroupItem: (props: RadioGroupItemProperties & RefAttributes<ContainerRef>) => ReactNode = forwardRef(
   ({ disabled = false, value, children, ...props }, ref) => {


### PR DESCRIPTION
This PR allows "undefined" as a radiogroup option, to match RadioGroup defaultValue also being optional.