### PR TITLE
feat: preserve data-* attributes in element.userData

### DIFF
--- a/packages/uikitml/src/interpreter/index.ts
+++ b/packages/uikitml/src/interpreter/index.ts
@@ -95,6 +95,15 @@ function interpretElement(json: ElementJson | string, kit?: Kit): Object3D<Objec
     element.userData.dataUid = json.dataUid
   }
 
+  // Preserve data-* attributes in userData, removing data prefix and lowercasing first letter
+  for (const [key, value] of Object.entries(properties)) {
+    if (key.startsWith('data')) {
+      // Remove 'data' prefix and lowercase the first letter of the remaining part
+      const userDataKey = key.slice(4, 5).toLowerCase() + key.slice(5)
+      element.userData[userDataKey] = value
+    }
+  }
+
   if (properties.class) {
     const classNames = (properties.class as string).split(' ').filter((name) => name.trim())
     element.classList.add(...classNames)

--- a/packages/uikitml/test/interpreter.spec.ts
+++ b/packages/uikitml/test/interpreter.spec.ts
@@ -187,6 +187,26 @@ describe('interpreter', () => {
       // Verify UIKit automatically applied the __id__ class
       expect((result as any)?.classList?.contains('__id__testButton')).to.be.true
     })
+
+    it('should preserve data-* attributes in userData', () => {
+      const htmlWithDataAttrs = `
+        <span
+          class="color-swatch"
+          style="background-color: #1f2937"
+          data-value="#1f2937"
+          data-type="color"
+          data-custom-id="123"
+        ></span>
+      `
+      const { result } = safeInterpret(htmlWithDataAttrs)
+
+      // Verify data-value is transformed to value
+      expect(result?.userData.value).to.equal('#1f2937')
+      
+      // Verify other data attributes have data prefix removed and first letter lowercased
+      expect(result?.userData.type).to.equal('color')
+      expect(result?.userData.customId).to.equal('123')
+    })
   })
 
   describe('children processing', () => {


### PR DESCRIPTION
- Convert data-* attributes to userData by removing 'data' prefix and lowercasing first
  letter
  - dataValue becomes userData.value, dataType becomes userData.type, etc.
  - Add test coverage for data attribute preservation