### PR TITLE
fix: Update yoga-layout import path to avoid TLA

### DIFF
--- a/packages/uikit/src/components/component.ts
+++ b/packages/uikit/src/components/component.ts
@@ -11,7 +11,7 @@ import {
   setupPointerEvents,
 } from '../utils.js'
 import { computedPanelMatrix, InstancedPanelMesh, panelGeometry, setupBoundingSphere } from '../panel/index.js'
-import { Overflow } from 'yoga-layout'
+import { Overflow } from 'yoga-layout/load'
 import { computedIsClipped } from '../clipping.js'
 import { FlexNode, Inset } from '../flex/node.js'
 import { OrderInfo } from '../order.js'


### PR DESCRIPTION
Fixes `Overflow` import path to avoid TLA issues with some bundlers.  