### PR TITLE
fix: pass value prop to progress component

### DIFF
--- a/packages/kits/default/src/progress.ts
+++ b/packages/kits/default/src/progress.ts
@@ -35,6 +35,7 @@ export class Progress<T = {}, EM extends ThreeEventMap = ThreeEventMap> extends 
       width: '100%',
       borderRadius: 1000,
       backgroundColor: colors.secondary,
+      value,
       ...rest,
     })
   }


### PR DESCRIPTION
Progress component wasn't passing the `value` prop through `internalResetProperties`, causing all progress bars to render as empty. Added missing value property to fix progress bar rendering.