### PR TITLE
fix: escape special characters

### DIFF
--- a/docs/getting-started/components-and-properties.md
+++ b/docs/getting-started/components-and-properties.md
@@ -151,13 +151,13 @@ Just like in html/css, all uikit components have a certain properties in common,
 | selectionBorderLeftWidth         | number                                                                                                                |
 | selectionBorderBottomWidth       | number                                                                                                                |
 | pointerEvents                    | "none", "auto", "listener"                                                                                            |
-| pointerEventsType                | `"all", { allow: string, string[] }, { deny: string | string[] }, (fn)`                                        |
+| pointerEventsType                | `"all", \{ allow: string, string[] \}, \{ deny: string | string[] \}, (fn)`                                        |
 | pointerEventsOrder               | number                                                                                                                |
 | anchorX                          | "left", "center", "middle", "right"                                                                                   |
 | anchorY                          | "top", "center", "middle", "bottom"                                                                                   |
 | id                               | string                                                                                                                |
 | cursor                           | string                                                                                                                |
-| fontFamilies                     | `Record<string, Partial<Record<FontWeight, string | FontInfo>>>`                                                       |
+| fontFamilies                     | `Record<string, Partial<Record<FontWeight, string \| FontInfo>>>`                                                       |
 
 </details>
 


### PR DESCRIPTION
Building the docs was failing due to a few characters not being excaped properly.

To test this locally, run this in your terminal:
```bash
docker run --rm --init \
  -v ./docs:/app/docs \
  -e BASE_PATH="/uikit/docs" \
  -e DIST_DIR="docs/out/uikit/docs" \
  -e MDX="docs" \
  -e NEXT_PUBLIC_LIBNAME="@pmndrs/uikit" \
  -e OUTPUT=export \
  ghcr.io/pmndrs/docs:2 npm run build
```

This should build the docs and not yield any mdx formatting errors.