### PR TITLE
fix: explicitly set Float32Array type to avoid generics

### DIFF
--- a/packages/uikit/src/clipping.ts
+++ b/packages/uikit/src/clipping.ts
@@ -171,7 +171,7 @@ export function computedClippingRect(
 }
 
 export const NoClippingPlane = new Plane(new Vector3(-1, 0, 0), Number.MAX_SAFE_INTEGER)
-export const defaultClippingData = new Float32Array(16)
+export const defaultClippingData: Float32Array = new Float32Array(16)
 for (let i = 0; i < 4; i++) {
   NoClippingPlane.normal.toArray(defaultClippingData, i * 4)
   defaultClippingData[i * 4 + 3] = NoClippingPlane.constant

--- a/packages/uikit/src/panel/panel-material.ts
+++ b/packages/uikit/src/panel/panel-material.ts
@@ -77,7 +77,7 @@ export function createPanelMaterialConfig(
       fn(data, offset, (value ?? defaultValue) as any, size, opacity, onUpdate)
   }
 
-  const defaultData = new Float32Array(16) //filled with 0s by default
+  const defaultData: Float32Array = new Float32Array(16) //filled with 0s by default
   writeColor(defaultData, 4, defaults.backgroundColor, defaultOpacity, undefined)
   writeColor(defaultData, 9, defaults.borderColor, defaultOpacity, undefined)
   defaultData[13] = defaults.borderBend


### PR DESCRIPTION
Current TypeScript setup emits `Float32Array<ArrayBuffer>` generics in declarations, breaking compatibility with TS < 5.7 where Float32Array is not generic.

Fixed by explicitly typing `Float32Array` constants to prevent generic emission.