### PR TITLE
fix: style shallow copy issue

### DIFF
--- a/packages/uikit/src/properties/index.ts
+++ b/packages/uikit/src/properties/index.ts
@@ -153,11 +153,12 @@ export class PropertiesImplementation<OutProperties extends BaseOutProperties = 
           WithSignal<WithInitial<Partial<OutProperties>>>
         >
         if (getConditional != null) {
-          for (const [key, value] of Object.entries(conditionalProperties)) {
-            conditionalProperties[key as keyof AddAllAliases<WithSignal<OutProperties>>] = computed(() =>
-              getConditional() ? (value instanceof Signal ? value.value : value) : undefined,
-            ) as any
-          }
+          conditionalProperties = Object.fromEntries(
+            Object.entries(conditionalProperties).map(([key, value]) => [
+              key,
+              computed(() => (getConditional() ? (value instanceof Signal ? value.value : value) : undefined)),
+            ]),
+          ) as AddAllAliases<WithSignal<WithInitial<Partial<OutProperties>>>>
         }
         this.setLayer(layerIndex, conditionalProperties)
       }


### PR DESCRIPTION
When creating reactivity for attributes, create a new object to avoid conflicts when multiple instances share attributes. 

The commit comes with an example placed under `examples/error`, which can reproduce this issue and serves only as an explanation for the modification. Once approved, I will remove this example from PR. 