### PR TITLE
fix: <Portal> framebuffer zero size warning

### DIFF
--- a/packages/react/src/portal.tsx
+++ b/packages/react/src/portal.tsx
@@ -244,6 +244,10 @@ function ChildrenToFBO({
     if (currentFBO == null || imageRef.current?.isVisible?.peek() != true) {
       return
     }
+    // Check if the render target has a valid size to prevent GL_INVALID_FRAMEBUFFER_OPERATION errors
+    if (currentFBO.width <= 0 || currentFBO.height <= 0) {
+      return
+    }
     if (frames === Infinity || count < frames) {
       oldAutoClear = state.gl.autoClear
       oldXrEnabled = state.gl.xr.enabled


### PR DESCRIPTION
Currently, when using the `<Portal>` component, a warning will be reported.

![img_v3_02se_1138e780-53dc-4047-b79a-bc3f9335a4ag](https://github.com/user-attachments/assets/3d6db6f4-00cd-404e-9e1f-5eb5db6ac751)

It can be easily reproduced by visiting `examples/uikit`.

The reason is the width and height of the Image used internally by Portal are 0 when initial. After analyzing the relevant code, I believe that adding a guard in `ChildrenToFBO` is a reasonable solution. If there are different opinions, feel free to modify it. 
