### PR TITLE
feat: add object3DName and userData props for Object3D access

### DIFF
--- a/packages/react/src/build.tsx
+++ b/packages/react/src/build.tsx
@@ -10,16 +10,23 @@ declare module 'three' {
   }
 }
 
+export interface UIKitObject3DProps {
+  /** Name for the underlying Object3D (useful for debugging and scene traversal) */
+  object3DName?: string
+  /** Custom user data attached to the underlying Object3D */
+  userData?: Record<string, any>
+}
+
 export function build<T extends Component, P>(Component: { new (): T }, name = Component.name) {
   extend({ [`Vanilla${name}`]: Component })
-  return forwardRef<T, P>(({ children, ...props }: any, forwardRef) => {
+  return forwardRef<T, P & UIKitObject3DProps>(({ children, ...props }: any, forwardRef) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const ref = useRef<Component>(null)
     useImperativeHandle(forwardRef, () => ref.current! as T, [])
     const renderContext = useRenderContext()
     const args = useMemo(() => [undefined, undefined, { renderContext }], [renderContext])
     const outProps = useSetup(ref, props, args)
-    return jsx(`vanilla${name}` as any, { ref, children, ...outProps })
+    return jsx(`vanilla${name}` as any, { ref, children, ...outProps, name: props.object3DName, userData: props.userData })
   })
 }
 

--- a/packages/react/test/index.spec.tsx
+++ b/packages/react/test/index.spec.tsx
@@ -16,3 +16,21 @@ test('Container onClick fires', async () => {
   await renderer.fireEvent(button, 'click')
   expect(clicked).toBe(true)
 })
+
+test('Container object3DName sets underlying Object3D name', async () => {
+  const renderer = await ReactThreeTestRenderer.create(
+    <Container object3DName="my-container" />,
+  )
+
+  const container = renderer.scene.children[0]!
+  expect((container as any).instance.name).toBe('my-container')
+})
+
+test('Container userData sets underlying Object3D userData', async () => {
+  const renderer = await ReactThreeTestRenderer.create(
+    <Container userData={{ testId: 'container-1', custom: { nested: true } }} />,
+  )
+
+  const container = renderer.scene.children[0]!
+  expect((container as any).instance.userData).toEqual({ testId: 'container-1', custom: { nested: true } })
+})


### PR DESCRIPTION
## Summary
- Adds `object3DName` prop to set the underlying Three.js Object3D's `name` property
- Adds `userData` prop to set custom user data on the Object3D
- Both props are available on all components built with the `build()` wrapper

## Motivation
These props are useful for debugging and writing automated tests, allowing developers to:
- Identify components by name in the Three.js scene graph, then interact with them in tests
- Attach custom metadata to components for test assertions or runtime inspection
