### PR TITLE
Add duplicate import checker and non-duplicate generator

### DIFF
--- a/docs/default-kit/card.mdx
+++ b/docs/default-kit/card.mdx
@@ -19,7 +19,7 @@ nav: 23
   files={{
     '/App.tsx': `import { Canvas } from "@react-three/fiber";
 import { Fullscreen } from "@react-three/uikit";
-import { colors } from "@react-three/uikit-default";
+
 import { Text, Container } from '@react-three/uikit'
 import { BellRing, Check } from '@react-three/uikit-lucide'
 import {

--- a/docs/default-kit/separator.mdx
+++ b/docs/default-kit/separator.mdx
@@ -19,7 +19,7 @@ nav: 31
   files={{
     '/App.tsx': `import { Canvas } from "@react-three/fiber";
 import { Fullscreen } from "@react-three/uikit";
-import { colors } from "@react-three/uikit-default";
+
 import { Text, Container } from '@react-three/uikit'
 import { colors, Separator } from '@react-three/uikit-default'
 

--- a/docs/horizon-kit/divider.mdx
+++ b/docs/horizon-kit/divider.mdx
@@ -72,8 +72,6 @@ function DividerDemo() {
   )
 }
 
-
-
 export default function App() {
   return (
     <Canvas style={{ position: "absolute", inset: "0", touchAction: "none" }} gl={{ localClippingEnabled: true }}>

--- a/docs/horizon-kit/panel.mdx
+++ b/docs/horizon-kit/panel.mdx
@@ -19,7 +19,7 @@ nav: 50
   files={{
     '/App.tsx': `import { Canvas } from "@react-three/fiber";
 import { Fullscreen } from "@react-three/uikit";
-import { Panel } from "@react-three/uikit-horizon";
+
 import { Container, Text } from '@react-three/uikit'
 import { Panel } from '@react-three/uikit-horizon'
 

--- a/generate-kit-docs.js
+++ b/generate-kit-docs.js
@@ -119,14 +119,13 @@ function generateMarkdown(nav, kit, component) {
   }
   const needsColors = kit === 'default' && !hasNamedImport(content, '@react-three/uikit-default', 'colors')
   const needsPanel = kit === 'horizon' && !hasNamedImport(content, '@react-three/uikit-horizon', 'Panel')
-  const kitWrapperImport =
-    kit === 'default'
-      ? needsColors
-        ? `import { colors } from "@react-three/uikit-default";`
-        : ''
-      : needsPanel
-        ? 'import { Panel } from "@react-three/uikit-horizon";'
-        : ''
+
+  let kitWrapperImport = ''
+  if (kit === 'default' && needsColors) {
+    kitWrapperImport = 'import { colors } from "@react-three/uikit-default";'
+  } else if (kit === 'horizon' && needsPanel) {
+    kitWrapperImport = 'import { Panel } from "@react-three/uikit-horizon";'
+  }
 
   return `---
 title: ${capitalize(component)}

--- a/generate-kit-docs.js
+++ b/generate-kit-docs.js
@@ -87,8 +87,7 @@ function getImportStatements(source) {
 function hasNamedImport(source, moduleName, importName) {
   const statements = getImportStatements(source)
   for (const statement of statements) {
-    const matchesModule =
-      statement.includes(`from "${moduleName}"`) || statement.includes(`from '${moduleName}'`)
+    const matchesModule = statement.includes(`from "${moduleName}"`) || statement.includes(`from '${moduleName}'`)
     if (!matchesModule) {
       continue
     }
@@ -118,8 +117,7 @@ function generateMarkdown(nav, kit, component) {
     console.error(content)
     throw new Error()
   }
-  const needsColors =
-    kit === 'default' && !hasNamedImport(content, '@react-three/uikit-default', 'colors')
+  const needsColors = kit === 'default' && !hasNamedImport(content, '@react-three/uikit-default', 'colors')
   const needsPanel = kit === 'horizon' && !hasNamedImport(content, '@react-three/uikit-horizon', 'Panel')
   const kitWrapperImport =
     kit === 'default'

--- a/generate-kit-docs.js
+++ b/generate-kit-docs.js
@@ -190,7 +190,7 @@ import { ${capitalize(component)} } from "@react-three/uikit-${kit}";
 let i = 17
 const defaultComponentFiles = readdirSync('./examples/default/src/components', { withFileTypes: true })
   .filter((entry) => entry.isFile() && entry.name.endsWith('.tsx'))
-  .map((entry) => entry.name.slice(0, -4))
+  .map((entry) => entry.name.replace(/\.tsx$/, ''))
 
 for (const component of defaultComponentFiles) {
   writeFileSync(`./docs/default-kit/${component}.mdx`, generateMarkdown(i++, 'default', component))
@@ -198,7 +198,7 @@ for (const component of defaultComponentFiles) {
 
 const horizonComponentFiles = readdirSync('./examples/horizon/src/components', { withFileTypes: true })
   .filter((entry) => entry.isFile() && entry.name.endsWith('.tsx'))
-  .map((entry) => entry.name.slice(0, -4))
+  .map((entry) => entry.name.replace(/\.tsx$/, ''))
 
 for (const component of horizonComponentFiles) {
   writeFileSync(`./docs/horizon-kit/${component}.mdx`, generateMarkdown(i++, 'horizon', component))

--- a/scripts/check-docs-mdx.mjs
+++ b/scripts/check-docs-mdx.mjs
@@ -155,8 +155,7 @@ function findDuplicateImports(code, ts) {
 async function main() {
   await ensureDeps()
   const { compile } = await import('@mdx-js/mdx')
-  const tsModule = await import('typescript')
-  const ts = tsModule.default ?? tsModule
+  const ts = await import('typescript')
 
   const root = fileURLToPath(new URL('..', import.meta.url))
   const docsDir = join(root, 'docs')

--- a/scripts/check-docs-mdx.mjs
+++ b/scripts/check-docs-mdx.mjs
@@ -7,12 +7,20 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 
 // Lazy import to avoid requiring deps unless invoked
 async function ensureDeps() {
+  const missing = []
   try {
     await import('@mdx-js/mdx')
   } catch {
-    console.error('Missing devDependency: @mdx-js/mdx. Install it with: pnpm add -D @mdx-js/mdx')
-    process.exitCode = 1
-    process.exit()
+    missing.push('@mdx-js/mdx')
+  }
+  try {
+    await import('typescript')
+  } catch {
+    missing.push('typescript')
+  }
+  if (missing.length) {
+    console.error(`Missing devDependencies: ${missing.join(', ')}. Install them with: pnpm add -D ${missing.join(' ')}`)
+    process.exit(1)
   }
 }
 
@@ -28,9 +36,133 @@ async function* walk(dir) {
   }
 }
 
+function extractSandpackFiles(src) {
+  const files = []
+  const marker = 'files={{'
+  let index = 0
+
+  while ((index = src.indexOf(marker, index)) !== -1) {
+    index += marker.length
+    while (index < src.length) {
+      index = skipWhitespace(src, index)
+      if (src.startsWith('}}', index)) {
+        index += 2
+        break
+      }
+      const quoted = readQuotedString(src, index)
+      if (!quoted) {
+        index += 1
+        continue
+      }
+      index = skipWhitespace(src, quoted.endIndex + 1)
+      if (src[index] !== ':') {
+        index += 1
+        continue
+      }
+      index = skipWhitespace(src, index + 1)
+      if (src[index] !== '`') {
+        index += 1
+        continue
+      }
+      const template = readTemplateLiteral(src, index)
+      files.push({ path: quoted.value, code: template.value })
+      index = template.endIndex + 1
+    }
+  }
+
+  return files
+}
+
+function skipWhitespace(src, index) {
+  let i = index
+  while (i < src.length && /\s/.test(src[i])) {
+    i += 1
+  }
+  return i
+}
+
+function readQuotedString(src, startIndex) {
+  const quote = src[startIndex]
+  if (quote !== '"' && quote !== "'") return null
+  let i = startIndex + 1
+  while (i < src.length) {
+    if (src[i] === quote) {
+      return { value: src.slice(startIndex + 1, i), endIndex: i }
+    }
+    i += 1
+  }
+  return null
+}
+
+function readTemplateLiteral(src, startIndex) {
+  let i = startIndex + 1
+  while (i < src.length) {
+    if (src[i] === '`' && src[i - 1] !== '\\') {
+      return { value: src.slice(startIndex + 1, i), endIndex: i }
+    }
+    i += 1
+  }
+  return { value: src.slice(startIndex + 1), endIndex: src.length - 1 }
+}
+
+function isCodeFile(filePath) {
+  return (
+    filePath.endsWith('.ts') ||
+    filePath.endsWith('.tsx') ||
+    filePath.endsWith('.js') ||
+    filePath.endsWith('.jsx')
+  )
+}
+
+function findDuplicateImports(code, ts) {
+  const sourceFile = ts.createSourceFile('App.tsx', code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+  const seen = new Map()
+  const duplicates = []
+
+  const record = (moduleName, importName, node) => {
+    const key = `${moduleName}|${importName}`
+    const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
+    const entry = { line: line + 1, column: character + 1 }
+    const existing = seen.get(key)
+    if (existing) {
+      duplicates.push({
+        moduleName,
+        importName,
+        first: existing,
+        second: entry,
+      })
+    } else {
+      seen.set(key, entry)
+    }
+  }
+
+  sourceFile.forEachChild((node) => {
+    if (!ts.isImportDeclaration(node) || !node.importClause || !ts.isStringLiteral(node.moduleSpecifier)) {
+      return
+    }
+    const moduleName = node.moduleSpecifier.text
+
+    if (node.importClause.name) {
+      record(moduleName, 'default', node.importClause.name)
+    }
+
+    const bindings = node.importClause.namedBindings
+    if (bindings && ts.isNamedImports(bindings)) {
+      for (const element of bindings.elements) {
+        const importName = element.propertyName ? element.propertyName.text : element.name.text
+        record(moduleName, importName, element.name)
+      }
+    }
+  })
+
+  return duplicates
+}
+
 async function main() {
   await ensureDeps()
   const { compile } = await import('@mdx-js/mdx')
+  const tsModule = await import('typescript')
+  const ts = tsModule.default ?? tsModule
 
   const root = fileURLToPath(new URL('..', import.meta.url))
   const docsDir = join(root, 'docs')
@@ -45,17 +177,38 @@ async function main() {
   for (const file of targets) {
     const url = pathToFileURL(file)
     const src = await readFile(file, 'utf8')
+    const errors = []
     try {
       // Use MDX v3 compile; we don't care about output, just parsing
       await compile(src, { filepath: url })
-      // eslint-disable-next-line no-console
-      console.log(`OK  ${file}`)
     } catch (err) {
+      errors.push(String(err && err.message ? err.message : err))
+    }
+
+    const sandpackFiles = extractSandpackFiles(src)
+    for (const sandpackFile of sandpackFiles) {
+      if (!isCodeFile(sandpackFile.path)) {
+        continue
+      }
+      const duplicates = findDuplicateImports(sandpackFile.code, ts)
+      for (const duplicate of duplicates) {
+        errors.push(
+          `duplicate import "${duplicate.importName}" from "${duplicate.moduleName}" in ${sandpackFile.path} (lines ${duplicate.first.line}, ${duplicate.second.line})`,
+        )
+      }
+    }
+
+    if (errors.length > 0) {
       hadError = true
       // eslint-disable-next-line no-console
       console.error(`ERR ${file}`)
+      for (const message of errors) {
+        // eslint-disable-next-line no-console
+        console.error(`  ${message}`)
+      }
+    } else {
       // eslint-disable-next-line no-console
-      console.error(String(err && err.message ? err.message : err))
+      console.log(`OK  ${file}`)
     }
   }
 
@@ -68,5 +221,3 @@ main().catch((e) => {
   console.error(e)
   process.exit(1)
 })
-
-

--- a/scripts/check-docs-mdx.mjs
+++ b/scripts/check-docs-mdx.mjs
@@ -106,12 +106,7 @@ function readTemplateLiteral(src, startIndex) {
 }
 
 function isCodeFile(filePath) {
-  return (
-    filePath.endsWith('.ts') ||
-    filePath.endsWith('.tsx') ||
-    filePath.endsWith('.js') ||
-    filePath.endsWith('.jsx')
-  )
+  return /\.(tsx?|jsx?)$/.test(filePath)
 }
 
 function findDuplicateImports(code, ts) {

--- a/scripts/check-docs-mdx.mjs
+++ b/scripts/check-docs-mdx.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-import { readdir } from 'node:fs/promises'
-import { readFile } from 'node:fs/promises'
+import { readdir, readFile } from 'node:fs/promises'
 import { extname, join } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath, pathToFileURL } from 'node:url'


### PR DESCRIPTION
 ## Summary
- Avoid duplicate kit wrapper imports in `generate-kit-docs.js`
- Detect duplicate imports inside Sandpack code in `scripts/check-docs-mdx.mjs`

## Changes
- Add import statement extraction and named import checks; only inject `colors`/`Panel` when needed
- Parse `files={{ ... }}` blocks and use TypeScript to flag duplicate imports as errors
- Regenerate `docs/default-kit/*` and `docs/horizon-kit/*` with `generate-kit-docs.js`

Ref: #244 