### PR TITLE
fix: <Image> was ignoring changes to opacity

### DIFF
--- a/packages/uikit/src/components/image.ts
+++ b/packages/uikit/src/components/image.ts
@@ -9,6 +9,7 @@ import {
   PanelDepthMaterial,
   PanelDistanceMaterial,
   PanelMaterialConfig,
+  writeColor,
 } from '../panel/panel-material.js'
 import { createGlobalClippingPlanes } from '../clipping.js'
 import { Inset } from '../flex/index.js'
@@ -149,6 +150,16 @@ export class Image<
         cleanupSizeEffect()
         cleanupBorderEffect()
       }
+    }, this.abortSignal)
+    abortableEffect(() => {
+      if (!this.isVisible.value) {
+        return
+      }
+      const opacity = this.properties.value.opacity ?? 1
+      const resolvedOpacity = typeof opacity === 'number' ? opacity : 1
+      const backgroundColor = this.properties.value.backgroundColor ?? 0xffffff
+      writeColor(data, 4, backgroundColor, resolvedOpacity, undefined)
+      this.root.peek().requestRender?.()
     }, this.abortSignal)
     const setters = imageMaterialConfig.setters
     abortableEffect(() => {

--- a/packages/uikit/src/components/image.ts
+++ b/packages/uikit/src/components/image.ts
@@ -17,6 +17,7 @@ import { ElementType, setupOrderInfo, setupRenderOrder } from '../order.js'
 import { componentDefaults } from '../properties/defaults.js'
 import { RenderContext } from '../context.js'
 import { resolvePanelMaterialClassProperty } from '../panel/instanced-panel-group.js'
+import { toAbsoluteNumber } from '../text/utils.js'
 
 export type ImageFit = 'cover' | 'fill'
 
@@ -155,10 +156,8 @@ export class Image<
       if (!this.isVisible.value) {
         return
       }
-      const opacity = this.properties.value.opacity ?? 1
-      const resolvedOpacity = typeof opacity === 'number' ? opacity : 1
-      const backgroundColor = this.properties.value.backgroundColor ?? 0xffffff
-      writeColor(data, 4, backgroundColor, resolvedOpacity, undefined)
+      const opacity = toAbsoluteNumber(this.properties.value.opacity ?? 1, () => 1)
+      writeColor(data, 4, 0xffffff, opacity, undefined)
       this.root.peek().requestRender?.()
     }, this.abortSignal)
     const setters = imageMaterialConfig.setters


### PR DESCRIPTION
Without this, the Image material's background tint stayed at alpha=1 regardless of the component's opacity property, for instance causing images to not follow their parent's opacity (e.g. via the '*' selector).