### PR TITLE
fix: Apply Kerning to Next Glyph During Font Rendering

### DIFF
--- a/packages/uikit/src/text/render/instanced-text.ts
+++ b/packages/uikit/src/text/render/instanced-text.ts
@@ -363,6 +363,10 @@ export class InstancedText {
                 this.parentClippingRect?.peek(),
               )
             }
+
+            // Calculate kerning here to ensure next glyph's x value accounts for it.
+            const kerningPx = (prevGlyphId == null ? 0 : font.getKerning(prevGlyphId, glyphInfo.id)) * fontSize
+
             glyph.updateGlyphAndTransformation(
               glyphInfo,
               x + getGlyphOffsetX(font, fontSize, glyphInfo, prevGlyphId),
@@ -372,7 +376,8 @@ export class InstancedText {
             )
             glyph.show()
             prevGlyphId = glyphInfo.id
-            x += getOffsetToNextGlyph(fontSize, glyphInfo, letterSpacing)
+
+            x += getOffsetToNextGlyph(fontSize, glyphInfo, letterSpacing) + kerningPx
           }
 
           y += getOffsetToNextLine(lineHeight)


### PR DESCRIPTION
Some fonts have a very high kerning value for some character combinations.

For example, DMSans has a high kerning value for a capital T followed by lowercase e, o, and c. This led to the following character (let's say on the word Todo), the 3rd character would be much farther away than it should be.

From my understanding, the position of the next character after kerning is applied should account for said kerning.