### PR TITLE
fix: suppress spurious font warnings during R3F teardown

### DIFF
--- a/packages/uikit/src/text/font.ts
+++ b/packages/uikit/src/text/font.ts
@@ -69,6 +69,12 @@ export function computedFont(
     fontFamily ??= Object.keys(fontFamilies)[0]!
     let fontFamilyWeightMap = fontFamilies[fontFamily]
     if (fontFamilyWeightMap == null) {
+      // When fontFamiliesSignal.value is undefined, we are in a fallback state
+      // (e.g. during R3F teardown where parent removal resets properties).
+      // Skip font loading entirely to avoid both "unknown font family" and
+      // subsequent "Missing glyph info" warnings from using the wrong font.
+      if (fontFamiliesSignal.value == null) return
+
       const availableFontFamilyList = Object.keys(fontFamilies)
       fontFamilyWeightMap = fontFamilies[availableFontFamilyList[0] as any]!
       console.error(


### PR DESCRIPTION
## Problem

When React Three Fiber unmounts a component tree, `removeChild` calls `parent.object.remove(child.object)` on each three.js object. This triggers uikit's `"removed"` event handler (`updateParentState`), which calls `properties.setEnabled(false)`, resetting all property signals to their defaults.

Since `computedFont` uses a raw `effect()` (not controlled by `abortController`), it re-evaluates when `fontFamiliesSignal` changes to `undefined`. The effect falls back to `defaultFontFamiles` (`{ inter }`), and if the component had a non-default `fontFamily` (e.g. `"ja"` for Japanese), it logs:

- `unknown font family "ja". Available font families are "inter". Falling back to "inter".`
- `Missing glyph info for character "ラ"` (for each character not in the inter font)

These warnings are harmless — the component is being destroyed — but noisy, especially with CJK text that produces one warning per character.

## Fix

Skip font loading when `fontFamiliesSignal.value` is `undefined`. This value being `undefined` reliably indicates a fallback/teardown state (properties have been reset) rather than an explicit font configuration. In normal operation, `fontFamiliesSignal.value` is always set (either from own props or inherited from parent).

This prevents both the "unknown font family" error and the subsequent "Missing glyph info" warnings.

## Reproduction

1. Create a uikit `Container` with `fontFamilies` including a non-Latin font
2. Add `Text` children with `fontFamily` set to that font
3. Unmount the component tree (e.g. navigate away in a React app)
4. Observe console warnings during unmount