### PR TITLE
fix: svg: avoid Three.js boundingBox naming collision

### DIFF
--- a/packages/uikit/src/components/content.ts
+++ b/packages/uikit/src/components/content.ts
@@ -34,7 +34,7 @@ const positionHelper = new Vector3()
 const scaleHelper = new Vector3()
 const vectorHelper = new Vector3()
 
-export type BoundingBox = { size: Vector3; center: Vector3 }
+export type ContentBoundingBox = { size: Vector3; center: Vector3 }
 
 const RemeasureOnChildrenChangeDefault = true
 const DepthWriteDefaultDefault = true
@@ -43,7 +43,7 @@ const SupportFillPropertyDefault = false
 export class Content<
   OutProperties extends ContentOutProperties = ContentOutProperties,
 > extends Component<OutProperties> {
-  readonly boundingBox: Signal<BoundingBox | undefined>
+  readonly contentBoundingBox: Signal<ContentBoundingBox | undefined>
   readonly clippingPlanes: Array<Plane>
 
   private readonly childrenMatrix = new Matrix4()
@@ -55,7 +55,7 @@ export class Content<
       remeasureOnChildrenChange?: boolean
       depthWriteDefault?: boolean
       supportFillProperty?: boolean
-      boundingBox?: Signal<BoundingBox | undefined>
+      contentBoundingBox?: Signal<ContentBoundingBox | undefined>
       defaultOverrides?: InProperties<OutProperties>
       renderContext?: RenderContext
       defaults?: WithSignal<OutProperties>
@@ -71,15 +71,15 @@ export class Content<
         ...inputConfig?.defaultOverrides,
       } as InProperties<OutProperties>,
     })
-    this.boundingBox =
-      inputConfig?.boundingBox ?? signal<BoundingBox>({ size: new Vector3(1, 1.01, 1), center: new Vector3(0, 0, 0) })
+    this.contentBoundingBox =
+      inputConfig?.contentBoundingBox ?? signal<ContentBoundingBox>({ size: new Vector3(1, 1.01, 1), center: new Vector3(0, 0, 0) })
 
     abortableEffect(() => {
-      if (!this.properties.value.keepAspectRatio || this.boundingBox.value == null) {
+      if (!this.properties.value.keepAspectRatio || this.contentBoundingBox.value == null) {
         defaultAspectRatio.value = undefined
         return
       }
-      defaultAspectRatio.value = this.boundingBox.value.size.x / this.boundingBox.value.size.y
+      defaultAspectRatio.value = this.contentBoundingBox.value.size.x / this.contentBoundingBox.value.size.y
     }, this.abortSignal)
     this.material.visible = false
 
@@ -114,7 +114,7 @@ export class Content<
         this.size.value == null ||
         this.paddingInset.value == null ||
         this.borderInset.value == null ||
-        this.boundingBox.value == null
+        this.contentBoundingBox.value == null
       ) {
         this.childrenMatrix.copy(IdentityMatrix)
         return
@@ -136,14 +136,14 @@ export class Content<
           innerWidth * pixelSize,
           innerHeight * pixelSize,
           this.properties.value.keepAspectRatio
-            ? (innerHeight * pixelSize * this.boundingBox.value.size.z) / this.boundingBox.value.size.y
-            : this.boundingBox.value.size.z,
+            ? (innerHeight * pixelSize * this.contentBoundingBox.value.size.z) / this.contentBoundingBox.value.size.y
+            : this.contentBoundingBox.value.size.z,
         )
-        .divide(this.boundingBox.value.size)
+        .divide(this.contentBoundingBox.value.size)
 
-      positionHelper.copy(this.boundingBox.value.center).negate()
+      positionHelper.copy(this.contentBoundingBox.value.center).negate()
 
-      positionHelper.z -= alignmentZMap[this.properties.value.depthAlign] * this.boundingBox.value.size.z
+      positionHelper.z -= alignmentZMap[this.properties.value.depthAlign] * this.contentBoundingBox.value.size.z
       positionHelper.multiply(scaleHelper)
       positionHelper.add(
         vectorHelper.set((leftInset - rightInset) * 0.5 * pixelSize, (bottomInset - topInset) * 0.5 * pixelSize, 0),
@@ -263,7 +263,7 @@ export class Content<
       child.updateWorldMatrix = this.childUpdateWorldMatrix.bind(this, child)
     }
 
-    if (this.inputConfig?.boundingBox == null) {
+    if (this.inputConfig?.contentBoundingBox == null) {
       //no need to compute the bounding box ourselves
       box3Helper.makeEmpty()
       for (const child of this.children) {
@@ -279,7 +279,7 @@ export class Content<
       const center = new Vector3()
       box3Helper.getSize(size).max(smallValue)
       box3Helper.getCenter(center)
-      this.boundingBox.value = { center, size }
+      this.contentBoundingBox.value = { center, size }
     }
 
     this.root.peek().requestRender?.()

--- a/packages/uikit/src/components/svg.ts
+++ b/packages/uikit/src/components/svg.ts
@@ -1,5 +1,5 @@
 import { Material, Mesh, MeshBasicMaterial, ShapeGeometry, Vector3 } from 'three'
-import { BoundingBox, Content, ContentOutProperties } from './content.js'
+import { ContentBoundingBox, Content, ContentOutProperties } from './content.js'
 import { computed, signal } from '@preact/signals-core'
 import { abortableEffect, loadResourceWithParams } from '../utils.js'
 import { SVGLoader, SVGResult } from 'three/examples/jsm/loaders/SVGLoader.js'
@@ -24,13 +24,13 @@ export class Svg<OutProperties extends SvgOutProperties = SvgOutProperties> exte
       defaults?: WithSignal<OutProperties>
     },
   ) {
-    const boundingBox = signal<BoundingBox | undefined>(undefined)
+    const contentBoundingBox = signal<ContentBoundingBox | undefined>(undefined)
     super(inputProperties, initialClasses, {
       ...inputConfig,
       remeasureOnChildrenChange: false,
       depthWriteDefault: false,
       supportFillProperty: true,
-      boundingBox,
+      contentBoundingBox,
     })
 
     const svgResult = signal<Awaited<ReturnType<typeof loadSvg>>>(undefined)
@@ -46,7 +46,7 @@ export class Svg<OutProperties extends SvgOutProperties = SvgOutProperties> exte
     )
     abortableEffect(() => {
       const result = svgResult.value
-      boundingBox.value = result?.boundingBox
+      contentBoundingBox.value = result?.contentBoundingBox
       if (result == null || result.meshes.length === 0) {
         this.notifyAncestorsChanged()
         return
@@ -75,7 +75,7 @@ async function loadSvg({
 }: {
   src?: string
   content?: string
-}): Promise<{ meshes: Array<Mesh>; boundingBox?: BoundingBox } | undefined> {
+}): Promise<{ meshes: Array<Mesh>; contentBoundingBox?: ContentBoundingBox } | undefined> {
   if (src == null && content == null) {
     return undefined
   }
@@ -102,7 +102,7 @@ async function loadSvg({
       meshes.push(mesh)
     }
   }
-  let boundingBox: { center: Vector3; size: Vector3 } | undefined
+  let contentBoundingBox: { center: Vector3; size: Vector3 } | undefined
   const viewBoxNumbers = result.xml
     .getAttribute('viewBox')
     ?.split(/\s+/)
@@ -110,13 +110,13 @@ async function loadSvg({
     .filter((value) => !isNaN(value))
   if (viewBoxNumbers?.length === 4) {
     const [minX, minY, width, height] = viewBoxNumbers as [number, number, number, number]
-    boundingBox = {
+    contentBoundingBox = {
       center: new Vector3(width / 2 + minX, -height / 2 - minY, 0),
       size: new Vector3(width, height, 0.00001),
     }
   }
 
-  return { meshes, boundingBox }
+  return { meshes, contentBoundingBox }
 }
 
 function disposeSvg(result: Awaited<ReturnType<typeof loadSvg>>) {


### PR DESCRIPTION
## Summary

Rename internal/content sizing naming from `boundingBox` to `contentBoundingBox` to avoid collision/confusion with Three.js `boundingBox` naming.

<img width="382" height="253" alt="Screenshot 2026-04-17 at 11 30 11" src="https://github.com/user-attachments/assets/e61b59ea-e651-40aa-a28e-cec1d45e7ad9" />


## Why

`boundingBox` in UI kit content layer easy confuse with Three.js geometry/object `boundingBox`.
This change makes intent explicit: box used for content layout/scaling, not Three.js geometry metadata.

## Changes

- Renamed content box type:
  - `BoundingBox` -> `ContentBoundingBox`
- Renamed `Content` property:
  - `boundingBox` -> `contentBoundingBox`
- Renamed `Content` config override field:
  - `boundingBox` -> `contentBoundingBox`
- Updated all internal `Content` calculations to use new name.
- Updated `Svg` component integration:
  - local signal `boundingBox` -> `contentBoundingBox`
  - loader result field `boundingBox` -> `contentBoundingBox`
  - helper `getSvgBoundingBox` -> `getSvgContentBoundingBox`
  - all related references migrated.

## Breaking Change

Yes (TypeScript API rename):
- Code using `BoundingBox`, `boundingBox`, or config `boundingBox` must migrate to new names.

## Validation

- `npx tsc --noEmit -p packages/uikit/tsconfig.json` passed.