### PR TITLE
Prevent stale fallback font from flashing during async loading

### DIFF
--- a/packages/pub-sub/src/index.ts
+++ b/packages/pub-sub/src/index.ts
@@ -213,9 +213,11 @@ export class PropertiesImplementation<In, Out extends object> implements Propert
   }
 
   private updateAll() {
-    for (const key in this.propertyStateMap) {
-      this.update(key, this.propertyStateMap[key])
-    }
+    batch(() => {
+      for (const key in this.propertyStateMap) {
+        this.update(key, this.propertyStateMap[key])
+      }
+    })
   }
 
   destroy() {

--- a/packages/uikit/src/components/component.ts
+++ b/packages/uikit/src/components/component.ts
@@ -1,4 +1,4 @@
-import { computed, ReadonlySignal, Signal, signal } from '@preact/signals-core'
+import { batch, computed, ReadonlySignal, Signal, signal } from '@preact/signals-core'
 import { EventHandlersProperties } from '../events.js'
 import {
   BufferGeometry,
@@ -109,6 +109,7 @@ export class Component<OutProperties extends BaseOutProperties = BaseOutProperti
   readonly maxScrollPosition = signal<Partial<Vector2Tuple>>([undefined, undefined])
   readonly root: Signal<RootContext>
   readonly parentContainer = signal<Container | undefined>(undefined)
+  readonly isAttached = signal(false)
   readonly hoveredList = signal<Array<number>>([])
   readonly activeList = signal<Array<number>>([])
   readonly ancestorsHaveListenersSignal: Signal<boolean>
@@ -136,9 +137,13 @@ export class Component<OutProperties extends BaseOutProperties = BaseOutProperti
 
     //setting up the parent signal
     const updateParentState = () => {
-      this.parentContainer.value = this.parent instanceof Component ? (this.parent as Container) : undefined
-      ;(this.properties as PropertiesImplementation<OutProperties>).setEnabled(this.parent != null)
-      ;(this.starProperties as PropertiesImplementation<OutProperties>).setEnabled(this.parent != null)
+      batch(() => {
+        this.parentContainer.value = this.parent instanceof Component ? (this.parent as Container) : undefined
+        const isAttached = this.parent != null
+        ;(this.properties as PropertiesImplementation<OutProperties>).setEnabled(isAttached)
+        ;(this.starProperties as PropertiesImplementation<OutProperties>).setEnabled(isAttached)
+        this.isAttached.value = isAttached
+      })
     }
     this.addEventListener('added', updateParentState)
     this.addEventListener('removed', updateParentState)

--- a/packages/uikit/src/components/text.ts
+++ b/packages/uikit/src/components/text.ts
@@ -100,7 +100,7 @@ export class Text<OutProperties extends TextOutProperties = TextOutProperties> e
     )
 
     const fontFamilies = computedFontFamilies(this.properties, this.parentContainer)
-    this.fontSignal = computedFont(this.properties, fontFamilies)
+    this.fontSignal = computedFont(this.properties, fontFamilies, this.isAttached)
 
     setupOrderInfo(
       this.orderInfo,

--- a/packages/uikit/src/text/font.ts
+++ b/packages/uikit/src/text/font.ts
@@ -50,10 +50,13 @@ export function computedFontFamilies(properties: Properties, parent: Signal<Cont
 export function computedFont(
   properties: Properties,
   fontFamiliesSignal: Signal<FontFamilies | undefined>,
+  isAttachedSignal?: Signal<boolean>,
 ): Signal<Font | undefined> {
   const result = signal<Font | undefined>(undefined)
-  const resultUrl = signal<string | FontInfo | undefined>(undefined)
-  const url = computed<string | FontInfo>(() => {
+  const url = computed<string | FontInfo | undefined>(() => {
+    if (isAttachedSignal?.value === false) {
+      return undefined
+    }
     let fontWeight: FontWeight = properties.value.fontWeight
     if (typeof fontWeight === 'string') {
       fontWeight = parseFloat(fontWeight)
@@ -80,16 +83,14 @@ export function computedFont(
   })
   effect(() => {
     const currentUrl = url.value
+    if (currentUrl == null) {
+      return
+    }
     let aborted = false
-    loadCachedFont(currentUrl, (font) => {
-      if (!aborted) {
-        result.value = font
-        resultUrl.value = currentUrl
-      }
-    })
+    loadCachedFont(currentUrl, (font) => !aborted && (result.value = font))
     return () => (aborted = true)
   })
-  return computed(() => (resultUrl.value === url.value ? result.value : undefined))
+  return result
 }
 
 function getMatchingFontUrl(fontFamily: FontFamilyWeightMap, weight: number): string | FontInfo {

--- a/packages/uikit/src/text/font.ts
+++ b/packages/uikit/src/text/font.ts
@@ -52,7 +52,8 @@ export function computedFont(
   fontFamiliesSignal: Signal<FontFamilies | undefined>,
 ): Signal<Font | undefined> {
   const result = signal<Font | undefined>(undefined)
-  effect(() => {
+  const resultUrl = signal<string | FontInfo | undefined>(undefined)
+  const url = computed<string | FontInfo>(() => {
     let fontWeight: FontWeight = properties.value.fontWeight
     if (typeof fontWeight === 'string') {
       fontWeight = parseFloat(fontWeight)
@@ -75,12 +76,20 @@ export function computedFont(
         `unknown font family "${fontFamily}". Available font families are ${availableFontFamilyList.map((name) => `"${name}"`).join(', ')}. Falling back to "${availableFontFamilyList[0]}".`,
       )
     }
-    const url = getMatchingFontUrl(fontFamilyWeightMap, fontWeight)
+    return getMatchingFontUrl(fontFamilyWeightMap, fontWeight)
+  })
+  effect(() => {
+    const currentUrl = url.value
     let aborted = false
-    loadCachedFont(url, (font) => !aborted && (result.value = font))
+    loadCachedFont(currentUrl, (font) => {
+      if (!aborted) {
+        result.value = font
+        resultUrl.value = currentUrl
+      }
+    })
     return () => (aborted = true)
   })
-  return result
+  return computed(() => (resultUrl.value === url.value ? result.value : undefined))
 }
 
 function getMatchingFontUrl(fontFamily: FontFamilyWeightMap, weight: number): string | FontInfo {


### PR DESCRIPTION
To reproduce:
1. Provide a custom fontFamilies via a parent (Fullscreen/Container)
2. Use <Text fontFamily="custom">★</Text> with a character not in the default Inter character set. On initial render, observe console warnings:

[console.warn] Missing glyph info for character "★"

4. The text briefly renders as a black rectangle before the correct font loads