### PR TITLE
Fix rounded clipping regressions

### DIFF
--- a/packages/uikit/src/clipping-shader.ts
+++ b/packages/uikit/src/clipping-shader.ts
@@ -1,0 +1,62 @@
+export function getInstancedClippingFragment(): string {
+  return `
+        vec4 clipPlane0 = clipping[0];
+        vec4 clipPlane1 = clipping[1];
+        vec4 clipPlane2 = clipping[2];
+        vec4 clipPlane3 = clipping[3];
+        bool clipPlane0Packed = clipPlane0.z > 1.5;
+        bool clipPlane1Packed = clipPlane1.z > 1.5;
+        bool clipPlane2Packed = clipPlane2.z > 1.5;
+        bool clipPlane3Packed = clipPlane3.z > 1.5;
+        vec3 clipNormal0 = vec3(clipPlane0.xy, clipPlane0Packed ? 0.0 : clipPlane0.z);
+        vec3 clipNormal1 = vec3(clipPlane1.xy, clipPlane1Packed ? 0.0 : clipPlane1.z);
+        vec3 clipNormal2 = vec3(clipPlane2.xy, clipPlane2Packed ? 0.0 : clipPlane2.z);
+        vec3 clipNormal3 = vec3(clipPlane3.xy, clipPlane3Packed ? 0.0 : clipPlane3.z);
+        float clipDistBot = dot(localPosition, clipNormal0) + clipPlane0.w;
+        float clipDistLeft = dot(localPosition, clipNormal1) + clipPlane1.w;
+        float clipDistTop = dot(localPosition, clipNormal2) + clipPlane2.w;
+        float clipDistRight = dot(localPosition, clipNormal3) + clipPlane3.w;
+
+        float clipOpacity = 1.0;
+        float clipGradient0 = max(fwidth(clipDistBot) * 0.5, 0.00001);
+        float clipGradient1 = max(fwidth(clipDistLeft) * 0.5, 0.00001);
+        float clipGradient2 = max(fwidth(clipDistTop) * 0.5, 0.00001);
+        float clipGradient3 = max(fwidth(clipDistRight) * 0.5, 0.00001);
+        clipOpacity *= smoothstep(-clipGradient0, clipGradient0, clipDistBot);
+        clipOpacity *= smoothstep(-clipGradient1, clipGradient1, clipDistLeft);
+        clipOpacity *= smoothstep(-clipGradient2, clipGradient2, clipDistTop);
+        clipOpacity *= smoothstep(-clipGradient3, clipGradient3, clipDistRight);
+        if (clipOpacity < 0.01) discard;
+
+        float clipRadiusTL = clipPlane2Packed ? clipPlane2.z - 2.0 : 0.0;
+        float clipRadiusTR = clipPlane3Packed ? clipPlane3.z - 2.0 : 0.0;
+        float clipRadiusBR = clipPlane1Packed ? clipPlane1.z - 2.0 : 0.0;
+        float clipRadiusBL = clipPlane0Packed ? clipPlane0.z - 2.0 : 0.0;
+        float clipCornerOpacity = 1.0;
+        if (clipRadiusTL > 0.0 && clipDistTop < clipRadiusTL && clipDistLeft < clipRadiusTL) {
+          vec2 clipCornerDistance = vec2(clipRadiusTL - clipDistLeft, clipRadiusTL - clipDistTop);
+          float clipArcDistance = clipRadiusTL - length(clipCornerDistance);
+          float clipArcGradient = max(fwidth(clipArcDistance) * 0.5, 0.00001);
+          clipCornerOpacity *= smoothstep(-clipArcGradient, clipArcGradient, clipArcDistance);
+        }
+        if (clipRadiusTR > 0.0 && clipDistTop < clipRadiusTR && clipDistRight < clipRadiusTR) {
+          vec2 clipCornerDistance = vec2(clipRadiusTR - clipDistRight, clipRadiusTR - clipDistTop);
+          float clipArcDistance = clipRadiusTR - length(clipCornerDistance);
+          float clipArcGradient = max(fwidth(clipArcDistance) * 0.5, 0.00001);
+          clipCornerOpacity *= smoothstep(-clipArcGradient, clipArcGradient, clipArcDistance);
+        }
+        if (clipRadiusBR > 0.0 && clipDistBot < clipRadiusBR && clipDistRight < clipRadiusBR) {
+          vec2 clipCornerDistance = vec2(clipRadiusBR - clipDistRight, clipRadiusBR - clipDistBot);
+          float clipArcDistance = clipRadiusBR - length(clipCornerDistance);
+          float clipArcGradient = max(fwidth(clipArcDistance) * 0.5, 0.00001);
+          clipCornerOpacity *= smoothstep(-clipArcGradient, clipArcGradient, clipArcDistance);
+        }
+        if (clipRadiusBL > 0.0 && clipDistBot < clipRadiusBL && clipDistLeft < clipRadiusBL) {
+          vec2 clipCornerDistance = vec2(clipRadiusBL - clipDistLeft, clipRadiusBL - clipDistBot);
+          float clipArcDistance = clipRadiusBL - length(clipCornerDistance);
+          float clipArcGradient = max(fwidth(clipArcDistance) * 0.5, 0.00001);
+          clipCornerOpacity *= smoothstep(-clipArcGradient, clipArcGradient, clipArcDistance);
+        }
+        clipOpacity *= clipCornerOpacity;
+        if (clipOpacity < 0.01) discard;`
+}

--- a/packages/uikit/src/clipping.ts
+++ b/packages/uikit/src/clipping.ts
@@ -4,22 +4,72 @@ import type { Box3, Line3, Matrix3, Sphere, Vector2Tuple } from 'three'
 import { Overflow } from 'yoga-layout/load'
 import { Container } from './components/container.js'
 import { Component } from './components/component.js'
+import type { Properties } from './properties/index.js'
 import { Fix_TS_56_Float32Array } from './utils.js'
+import { resolvePanelBorderRadius } from './panel/material/radius.js'
 
 const dotLt45deg = Math.cos((45 / 180) * Math.PI)
+const packedCornerRadiusOffset = 2
+const packablePlaneZEpsilon = 1e-5
 
 const helperPlanes = [new Plane(), new Plane(), new Plane(), new Plane()]
 const positionHelper = new Vector3()
 
+/** Per-corner radii ordered [top-left, top-right, bottom-right, bottom-left]. */
+export type CornerRadii = [number, number, number, number]
+
+type SideIndex = 0 | 1 | 2 | 3
+type SideSource = { readonly rect: ClippingRect; readonly side: SideIndex }
+
+const cornerSides = [
+  [2, 1],
+  [2, 3],
+  [0, 3],
+  [0, 1],
+] as const satisfies ReadonlyArray<readonly [SideIndex, SideIndex]>
+
+function getCornerIndexForSides(side1: SideIndex, side2: SideIndex): number | undefined {
+  for (let i = 0; i < 4; i++) {
+    const [c1, c2] = cornerSides[i]!
+    if ((side1 === c1 && side2 === c2) || (side1 === c2 && side2 === c1)) {
+      return i
+    }
+  }
+  return undefined
+}
+
 export class ClippingRect {
   public readonly planes: Array<Plane>
 
+  /**
+   * Per-corner radii in world-space distance units, ordered
+   * [top-left, top-right, bottom-right, bottom-left]. These radii describe
+   * the final intersected rect. A corner only keeps a radius when both of its
+   * adjacent planes come from the same source rounded rect.
+   */
+  public readonly cornerRadii: CornerRadii = [0, 0, 0, 0]
+
+  private readonly ownCornerRadii: CornerRadii = [0, 0, 0, 0]
   private readonly facePlane: Plane
   private readonly originalCenter: Vector3
+  private readonly sideSources: [SideSource, SideSource, SideSource, SideSource]
 
-  constructor(globalMatrix: Matrix4, centerX: number, centerY: number, width: number, height: number) {
+  constructor(
+    globalMatrix: Matrix4,
+    centerX: number,
+    centerY: number,
+    width: number,
+    height: number,
+    cornerRadii?: CornerRadii | null,
+  ) {
     this.originalCenter = new Vector3(centerX, centerY, 0).applyMatrix4(globalMatrix)
     this.facePlane = new Plane(new Vector3(0, 0, 1), 0).applyMatrix4(globalMatrix)
+    this.sideSources = [
+      { rect: this, side: 0 },
+      { rect: this, side: 1 },
+      { rect: this, side: 2 },
+      { rect: this, side: 3 },
+    ]
     const halfWidth = width / 2
     const halfHeight = height / 2
     const top = centerY + halfHeight
@@ -33,9 +83,21 @@ export class ClippingRect {
       new Plane(new Vector3(0, 1, 0), top).applyMatrix4(globalMatrix),
       new Plane(new Vector3(1, 0, 0), right).applyMatrix4(globalMatrix),
     ]
+
+    if (cornerRadii != null) {
+      this.ownCornerRadii[0] = cornerRadii[0]
+      this.ownCornerRadii[1] = cornerRadii[1]
+      this.ownCornerRadii[2] = cornerRadii[2]
+      this.ownCornerRadii[3] = cornerRadii[3]
+      this.cornerRadii[0] = cornerRadii[0]
+      this.cornerRadii[1] = cornerRadii[1]
+      this.cornerRadii[2] = cornerRadii[2]
+      this.cornerRadii[3] = cornerRadii[3]
+    }
   }
 
-  min({ planes }: ClippingRect): this {
+  min(other: ClippingRect): this {
+    const { planes } = other
     for (let i = 0; i < 4; i++) {
       const p1 = this.facePlane
       const p2 = planes[i]!
@@ -72,8 +134,10 @@ export class ClippingRect {
         helperPlanes[otherPlaneIndex]!.distanceToPoint(this.originalCenter) < plane.distanceToPoint(this.originalCenter)
       ) {
         plane.copy(planes[otherPlaneIndex]!)
+        this.sideSources[i] = other.sideSources[otherPlaneIndex]!
       }
     }
+    this.updateCornerRadii()
     return this
   }
 
@@ -84,6 +148,37 @@ export class ClippingRect {
       ;(array as Array<number>)[offset + 3] = constant
       offset += 4
     }
+  }
+
+  toShaderArray(array: ArrayLike<number>, offset: number) {
+    this.toArray(array, offset)
+    if (!this.canPackCornerRadii()) {
+      return
+    }
+    const out = array as Array<number>
+    out[offset + 2] = this.cornerRadii[3]! + packedCornerRadiusOffset
+    out[offset + 6] = this.cornerRadii[2]! + packedCornerRadiusOffset
+    out[offset + 10] = this.cornerRadii[0]! + packedCornerRadiusOffset
+    out[offset + 14] = this.cornerRadii[1]! + packedCornerRadiusOffset
+  }
+
+  private canPackCornerRadii(): boolean {
+    return this.planes.every(({ normal }) => Math.abs(normal.z) < packablePlaneZEpsilon)
+  }
+
+  private updateCornerRadii(): void {
+    for (let i = 0; i < 4; i++) {
+      const [side1, side2] = cornerSides[i]!
+      this.cornerRadii[i] = this.getSourceCornerRadius(this.sideSources[side1], this.sideSources[side2])
+    }
+  }
+
+  private getSourceCornerRadius(source1: SideSource, source2: SideSource): number {
+    if (source1.rect !== source2.rect) {
+      return 0
+    }
+    const cornerIndex = getCornerIndexForSides(source1.side, source2.side)
+    return cornerIndex == null ? 0 : source1.rect.ownCornerRadii[cornerIndex]!
   }
 }
 
@@ -147,6 +242,7 @@ export function computedClippingRect(
   { overflow, borderInset, size }: Component,
   pixelSizeSignal: Signal<number>,
   parentClippingRect: Signal<ClippingRect | undefined> | undefined,
+  cornerRadiiPx?: Signal<CornerRadii | null>,
 ): Signal<ClippingRect | undefined> {
   return computed(() => {
     const global = globalMatrix.value
@@ -162,12 +258,23 @@ export function computedClippingRect(
     const [width, height] = sizeValue
     const [top, right, bottom, left] = borderInsetValue
     const pixelSize = pixelSizeSignal.value
+    const radiiPxValue = cornerRadiiPx?.value
+    const cornerRadii: CornerRadii | null =
+      radiiPxValue == null
+        ? null
+        : [
+            radiiPxValue[0] * pixelSize,
+            radiiPxValue[1] * pixelSize,
+            radiiPxValue[2] * pixelSize,
+            radiiPxValue[3] * pixelSize,
+          ]
     const rect = new ClippingRect(
       global,
       ((right - left) * pixelSize) / 2,
       ((top - bottom) * pixelSize) / 2,
       (width - left - right) * pixelSize,
       (height - top - bottom) * pixelSize,
+      cornerRadii,
     )
     if (parentClippingRectValue != null) {
       rect.min(parentClippingRectValue)
@@ -181,6 +288,39 @@ export const defaultClippingData: Fix_TS_56_Float32Array = new Float32Array(16)
 for (let i = 0; i < 4; i++) {
   NoClippingPlane.normal.toArray(defaultClippingData, i * 4)
   defaultClippingData[i * 4 + 3] = NoClippingPlane.constant
+}
+
+/**
+ * Resolve the four per-corner border radii against the node's current height,
+ * using the same quantization as the panel material. Returns null when all
+ * four corners are zero so callers can keep the existing rect-only fast path.
+ */
+export function computedCornerRadiiPx(
+  properties: Properties,
+  sizeSignal: Signal<Vector2Tuple | undefined>,
+): Signal<CornerRadii | null> {
+  return computed(() => {
+    const p = properties.value
+    const height = sizeSignal.value?.[1] ?? 0
+    const resolve = (raw: number | string | undefined): number => {
+      if (raw == null) {
+        return 0
+      }
+      try {
+        return resolvePanelBorderRadius(raw, height)
+      } catch {
+        return 0
+      }
+    }
+    const tl = resolve(p.borderTopLeftRadius)
+    const tr = resolve(p.borderTopRightRadius)
+    const br = resolve(p.borderBottomRightRadius)
+    const bl = resolve(p.borderBottomLeftRadius)
+    if (!(tl > 0) && !(tr > 0) && !(br > 0) && !(bl > 0)) {
+      return null
+    }
+    return [tl, tr, br, bl]
+  })
 }
 
 export function createGlobalClippingPlanes(component: Component) {

--- a/packages/uikit/src/components/container.ts
+++ b/packages/uikit/src/components/container.ts
@@ -2,7 +2,7 @@ import type { z } from 'zod'
 import { baseOutPropertiesSchema, createInPropertiesSchema, defineSchema } from '../properties/schema.js'
 import { computed, signal, Signal } from '@preact/signals-core'
 import { Matrix4, Vector2Tuple, Vector3, Vector2 } from 'three'
-import { ClippingRect, computedClippingRect } from '../clipping.js'
+import { ClippingRect, computedClippingRect, computedCornerRadiiPx } from '../clipping.js'
 import { ElementType, setupOrderInfo } from '../order.js'
 import { setupInstancedPanel } from '../panel/instance/setup.js'
 import { getDefaultPanelMaterialConfig } from '../panel/material/config.js'
@@ -72,6 +72,7 @@ export class Container<OutProperties extends BaseOutProperties = BaseOutProperti
       this,
       computed(() => parseNumberValue(this.properties.value.pixelSize)),
       parentClippingRect,
+      computedCornerRadiiPx(this.properties, this.size),
     )
 
     this.anyAncestorScrollable = computedAnyAncestorScrollable(this.parentContainer)

--- a/packages/uikit/src/panel/instance/panel.ts
+++ b/packages/uikit/src/panel/instance/panel.ts
@@ -149,7 +149,7 @@ export class InstancedPanel {
       const offset = index * 16
       const clipping = this.clippingRect?.value
       if (clipping != null) {
-        clipping.toArray(instanceClipping.array, offset)
+        clipping.toShaderArray(instanceClipping.array, offset)
       } else {
         instanceClipping.array.set(defaultClippingData, offset)
       }

--- a/packages/uikit/src/panel/material/data.ts
+++ b/packages/uikit/src/panel/material/data.ts
@@ -1,10 +1,10 @@
 import { Signal } from '@preact/signals-core'
 import { TypedArray, Vector2Tuple } from 'three'
-import { clamp } from 'three/src/math/MathUtils.js'
 import type { ColorRepresentation } from '../../utils.js'
 import { toAbsoluteNumber } from '../../text/utils.js'
 import { writeColor } from './color.js'
 import type { NumberOrPercentageValue } from '../../properties/values.js'
+import { resolvePackedBorderRadius } from './radius.js'
 
 export const materialSetters = {
   // 0-3 = border sizes
@@ -69,13 +69,7 @@ function writeBorderRadius(
   height: number,
   onUpdate: ((start: number, count: number) => void) | undefined,
 ): void {
-  setBorderRadius(
-    data,
-    offset,
-    indexInFloat,
-    toAbsoluteNumber(value, () => height),
-    height,
-  )
+  setBorderRadius(data, offset, indexInFloat, value, height)
   onUpdate?.(offset, 1)
 }
 
@@ -95,10 +89,12 @@ function setComponentInFloat(from: number, index: number, value: number): number
   return from + (value - currentValue) * x
 }
 
-function setBorderRadius(data: TypedArray, indexInData: number, indexInFloat: number, value: number, height: number) {
-  data[indexInData] = setComponentInFloat(
-    data[indexInData]!,
-    indexInFloat,
-    height === 0 ? 0 : clamp(Math.ceil(((value ?? 0) / height) * 100), 0, 49),
-  )
+function setBorderRadius(
+  data: TypedArray,
+  indexInData: number,
+  indexInFloat: number,
+  value: number | string,
+  height: number,
+) {
+  data[indexInData] = setComponentInFloat(data[indexInData]!, indexInFloat, resolvePackedBorderRadius(value, height))
 }

--- a/packages/uikit/src/panel/material/radius.ts
+++ b/packages/uikit/src/panel/material/radius.ts
@@ -1,0 +1,13 @@
+import { clamp } from 'three/src/math/MathUtils.js'
+import { toAbsoluteNumber } from '../../text/utils.js'
+
+export function resolvePackedBorderRadius(value: number | string, height: number): number {
+  if (height === 0) {
+    return 0
+  }
+  return clamp(Math.ceil((toAbsoluteNumber(value, () => height) / height) * 100), 0, 49)
+}
+
+export function resolvePanelBorderRadius(value: number | string, height: number): number {
+  return (resolvePackedBorderRadius(value, height) / 100) * height
+}

--- a/packages/uikit/src/panel/material/shader.ts
+++ b/packages/uikit/src/panel/material/shader.ts
@@ -1,4 +1,5 @@
 import type { WebGLProgramParametersWithUniforms } from 'three'
+import { getInstancedClippingFragment } from '../../clipping-shader.js'
 
 export function compilePanelDepthMaterial(parameters: WebGLProgramParametersWithUniforms, instanced: boolean) {
   compilePanelClippingMaterial(parameters, instanced)
@@ -106,21 +107,7 @@ function getFragmentShaderPrefix(instanced: boolean): string {
 }
 
 function getClippingPlanesFragment(instanced: boolean): string {
-  const instancedClipping = instanced
-    ? `
-        vec4 plane;
-        float distanceToPlane, planeDistanceGradient;
-        float clipOpacity = 1.0;
-
-        for(int i = 0; i < 4; i++) {
-          plane = clipping[i];
-          distanceToPlane = dot(localPosition, plane.xyz) + plane.w;
-          planeDistanceGradient = max(fwidth(distanceToPlane) * 0.5, 0.00001);
-          clipOpacity *= smoothstep(-planeDistanceGradient, planeDistanceGradient, distanceToPlane);
-    
-          if (clipOpacity < 0.01) discard;
-        }`
-    : ''
+  const instancedClipping = instanced ? getInstancedClippingFragment() : ''
 
   return ` ${instancedClipping}
         

--- a/packages/uikit/src/text/render/instanced-glyph-material.ts
+++ b/packages/uikit/src/text/render/instanced-glyph-material.ts
@@ -1,5 +1,6 @@
 import { MeshBasicMaterial } from 'three'
 import { Font } from '../font.js'
+import { getInstancedClippingFragment } from '../../clipping-shader.js'
 
 export class InstancedGlyphMaterial extends MeshBasicMaterial {
   constructor(font: Font) {
@@ -54,17 +55,7 @@ export class InstancedGlyphMaterial extends MeshBasicMaterial {
       parameters.fragmentShader = parameters.fragmentShader.replace(
         '#include <map_fragment>',
         ` #include <map_fragment>
-          vec4 plane;
-          float distanceToPlane, distanceGradient;
-          float clipOpacity = 1.0;
-          for(int i = 0; i < 4; i++) {
-            plane = clipping[ i ];
-            distanceToPlane = dot( localPosition, plane.xyz ) + plane.w;
-            distanceGradient = max(fwidth( distanceToPlane ) / 2.0, 0.00001);
-            clipOpacity *= smoothstep( - distanceGradient, distanceGradient, distanceToPlane );
-
-            if ( clipOpacity == 0.0 ) discard;
-          }
+          ${getInstancedClippingFragment()}
           // Distance to the edge of the glyph in texels.
           float dist = (getDistance() - 0.5) * float(distanceRange);
 

--- a/packages/uikit/src/text/render/instanced-glyph.ts
+++ b/packages/uikit/src/text/render/instanced-glyph.ts
@@ -82,7 +82,7 @@ export class InstancedGlyph {
     if (this.clippingRect == null) {
       instanceClipping.set(defaultClippingData, offset)
     } else {
-      this.clippingRect.toArray(instanceClipping.array, offset)
+      this.clippingRect.toShaderArray(instanceClipping.array, offset)
     }
     instanceClipping.addUpdateRange(offset, 16)
     instanceClipping.needsUpdate = true

--- a/packages/uikit/tests/clipping.spec.ts
+++ b/packages/uikit/tests/clipping.spec.ts
@@ -1,6 +1,8 @@
 import { Matrix4, Vector3 } from 'three'
-import { ClippingRect } from '../src/clipping.js'
+import { signal } from '@preact/signals-core'
+import { ClippingRect, computedCornerRadiiPx } from '../src/clipping.js'
 import { expect } from 'chai'
+import type { Properties } from '../src/properties/index.js'
 
 const defaultPlaneNormals = [new Vector3(0, -1, 0), new Vector3(-1, 0, 0), new Vector3(0, 1, 0), new Vector3(1, 0, 0)]
 
@@ -53,5 +55,61 @@ describe('clipping', () => {
     const rect2 = new ClippingRect(new Matrix4().makeRotationY((65 / 180) * Math.PI), 0, 0, 0.5, 1)
     rect1.min(rect2)
     expectClippingCenterAndSize(rect1, 0, 0, 1, 1)
+  })
+
+  it('should resolve rounded clipping radii like the panel material', () => {
+    const properties = {
+      value: {
+        borderTopLeftRadius: 1000,
+        borderTopRightRadius: 1000,
+        borderBottomRightRadius: 1000,
+        borderBottomLeftRadius: 1000,
+      },
+    } as unknown as Properties
+    const radii = computedCornerRadiiPx(properties, signal([48, 48])).value
+    expect(radii).to.not.equal(null)
+    for (const radius of radii!) {
+      expect(radius).to.equal(23.52)
+    }
+  })
+
+  it('should not inherit rounded corners from a larger parent that does not constrain the child', () => {
+    const parent = new ClippingRect(new Matrix4(), 0, 0, 100, 100, [20, 20, 20, 20])
+    const child = new ClippingRect(new Matrix4(), 0, 0, 10, 10)
+    child.min(parent)
+    expect(child.cornerRadii).to.deep.equal([0, 0, 0, 0])
+  })
+
+  it('should require both adjacent parent sides before applying a parent corner radius', () => {
+    const parent = new ClippingRect(new Matrix4(), 0, 0, 10, 10, [1, 2, 3, 4])
+    const child = new ClippingRect(new Matrix4(), -2, 0, 8, 4)
+    child.min(parent)
+    expect(child.cornerRadii).to.deep.equal([0, 0, 0, 0])
+  })
+
+  it('should keep the source radius when both adjacent parent sides constrain a corner', () => {
+    const parent = new ClippingRect(new Matrix4(), 0, 0, 10, 10, [1, 2, 3, 4])
+    const child = new ClippingRect(new Matrix4(), -2, 2, 8, 8)
+    child.min(parent)
+    expect(child.cornerRadii).to.deep.equal([1, 0, 0, 0])
+  })
+
+  it('should pack shader radii with a sentinel only for axis-aligned clipping planes', () => {
+    const rect = new ClippingRect(new Matrix4(), 0, 0, 10, 10, [1, 2, 3, 4])
+    const array = new Float32Array(16)
+    rect.toShaderArray(array, 0)
+    expect(array[2]).to.equal(6)
+    expect(array[6]).to.equal(5)
+    expect(array[10]).to.equal(3)
+    expect(array[14]).to.equal(4)
+  })
+
+  it('should preserve non-zero z normals instead of packing radii for tilted clipping planes', () => {
+    const rect = new ClippingRect(new Matrix4().makeRotationY((65 / 180) * Math.PI), 0, 0, 10, 10, [1, 2, 3, 4])
+    const array = new Float32Array(16)
+    rect.toShaderArray(array, 0)
+    expect(array[6]).to.be.closeTo(rect.planes[1]!.normal.z, 0.000001)
+    expect(array[14]).to.be.closeTo(rect.planes[3]!.normal.z, 0.000001)
+    expect(array[6]).to.be.lessThan(1.5)
   })
 })


### PR DESCRIPTION
## Summary
- clamp rounded clipping radii with the same quantization used by panel rendering
- preserve tilted clipping plane normals by only packing radii when planes are axis-aligned
- share rounded clipping shader logic between instanced panels and glyphs
- avoid inheriting parent corner radii unless both adjacent clipped sides come from the same rounded rect

## Test plan
- pnpm dlx node@22 /Users/fe1ix/.nvm/versions/node/v26.1.0/bin/pnpm --filter @pmndrs/uikit test
- pnpm --filter @pmndrs/uikit build
- pnpm --filter @pmndrs/uikit check:eslint
- pnpm --filter @pmndrs/uikit check:prettier
- git diff --check